### PR TITLE
36 services as global state

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,39 +1,19 @@
 import { Footer, Header } from 'webstore-component-library'
 import { FOOTER_NAME, FOOTER_SECTIONS, FOOTER_SOCIALS, LOGO } from '../constants/wrapper'
-import { fetcherB } from '../services/fetcher'
 import '../styles/globals.css'
 
 // putting the header and footer here mean that they automatically surround every page
-const Webstore = ({ Component, pageProps, data }) => {
-  const services = (path) => {
-    return data?.map(ware => {
-      const img = ware.promo_image
-        ? { src: ware.promo_image, alt: `The promotional image for ${ware.name}` }
-        : DEFAULT_WARE_IMAGE
-
-      return {
-        description: ware.snippet,
-        id: ware.reference_of_id,
-        img: {
-          src: ware.promo_image,
-          alt: `The promotional image for ${ware.name}`
-        },
-        name: ware.name,
-        href: `${path}/${ware.slug}`,
-      }
-    })
-  }
-
+const Webstore = ({ Component, pageProps }) => {
   return (
     <>
       <Header
-          browseLink='/browse'
-          logInLink='/login'
-          logo={LOGO}
-          logOutLink='/'
-          requestsLink='/requests'
-        />
-      <Component {...pageProps} services={services} />
+        browseLink='/browse'
+        logInLink='/login'
+        logo={LOGO}
+        logOutLink='/'
+        requestsLink='/requests'
+      />
+      <Component {...pageProps} />
       <Footer
         companyName={FOOTER_NAME}
         sections={FOOTER_SECTIONS}
@@ -43,13 +23,4 @@ const Webstore = ({ Component, pageProps, data }) => {
   )
 }
 
-Webstore.getInitialProps = async () => {
-  const url = `/providers/${process.env.NEXT_PUBLIC_PROVIDER_ID}/wares.json`
-  const data = await fetcher(url)
-
-  return { data: data.ware_refs }
-}
-
 export default Webstore
-
-

--- a/pages/browse/index.js
+++ b/pages/browse/index.js
@@ -1,63 +1,56 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
-import useSWR from 'swr'
 import { Item, SearchBar } from 'webstore-component-library'
-import { fetcher } from '../../services/fetcher'
+import { configure_services, useWares } from '../../services/utils'
 
 const Browse = () => {
-	const router = useRouter()
-	const [ query, setQuery ] = useState('')
-	const existingQuery = router.query.q
+  const router = useRouter()
+  const [query, setQuery] = useState('')
+  const existingQuery = router.query.q
 
-	useEffect(() => {
-		if(existingQuery) setQuery(existingQuery)
-	}, [])
+  useEffect(() => {
+    if (existingQuery) setQuery(existingQuery)
+  }, [])
 
-	// TODO(alishaevn): once the api is updated to accept a query with this path, we will want to use the second "url" declaration instead.
-	const url = () => `/providers/${process.env.NEXT_PUBLIC_PROVIDER_ID}/wares.json`
-	// const url = () => `/providers/${process.env.NEXT_PUBLIC_PROVIDER_ID}/wares.json&q=${query}`
-	const { data, error } = useSWR(url, fetcher)
+  // TODO(alishaevn): once the api is updated to accept a query with this path, we will want to replace the path in useWares on line 17, with the one on line 18
+  // and also delete the filter method from the "services" variable definition
+  const { wares, isLoading, isError } = useWares(`/providers/${process.env.NEXT_PUBLIC_PROVIDER_ID}/wares.json`)
+  // `/providers/${process.env.NEXT_PUBLIC_PROVIDER_ID}/wares.json&q=${query}`
+  const services = configure_services({ data: wares?.ware_refs, path: '/requests/new' })?.filter((ware) => {
+      const queryExpression = new RegExp(query, 'i')
+      return queryExpression.test(ware.name)
+    })
 
-	const handleOnSubmit = ({ value }) => setQuery(value)
+  const handleOnSubmit = ({ value }) => setQuery(value)
 
-	const wares = data?.ware_refs.filter((ware) => {
-		const queryExpression = new RegExp(query, 'i')
-		return queryExpression.test(ware.name)
-	})
+  if (isError) return <h1>Error...</h1>
 
-	const services = wares?.map(ware => {
-		return {
-			description: ware.snippet,
-			id: ware.reference_of_id,
-			img: {
-				src: ware.promo_image,
-				alt: `The promotional image for ${ware.name}`
-			},
-			name: ware.name,
-			slug: `/requests/new/${ware.slug}`,
-		}
-	})
-
-	return(
-		<>
-			<SearchBar onSubmit={handleOnSubmit} initialValue={existingQuery} />
-			{services && services.map(service => (
-					<Item
-						key={id}
-						item={service}
-						withButtonLink={true}
-						buttonLink={service.slug}
-						orientation='horizontal'
-						buttonProps={{
-							backgroundColor: '#A9A9A9',
-							label: 'Request this item',
-							primary: true,
-						}}
-						style={{ marginBottom: 30 }}
-					/>
-				))}
-		</>
-	)
+  return (
+    <>
+      <SearchBar onSubmit={handleOnSubmit} initialValue={existingQuery} />
+      {isLoading
+        ? (
+          <h1>Loading...</h1>
+        ) : (
+          services.map(service => (
+            <Item
+              key={service.id}
+              item={service}
+              withButtonLink={true}
+              buttonLink={service.href}
+              orientation='horizontal'
+              buttonProps={{
+                backgroundColor: '#A9A9A9',
+                label: 'Request this item',
+                primary: true,
+              }}
+              style={{ marginBottom: 30 }}
+            />
+          ))
+        )
+      }
+    </>
+  )
 }
 
 export default Browse

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,14 +7,18 @@ import {
 } from 'webstore-component-library'
 import hero from '../assets/img/hero.jpg'
 import { TEXT, TITLE } from '../constants/home'
+import { configure_services, useWares } from '../services/utils'
 
-const Home = ({ services }) => {
-	const router = useRouter()
-	const featured_services = services('/services').slice(0, 4)
-	const handleOnSubmit = ({ value }) => router.push({ pathname: '/browse', query: { q: value } }, '/browse')
+const Home = () => {
+  const router = useRouter()
+  const { wares, isLoading, isError } = useWares(`/providers/${process.env.NEXT_PUBLIC_PROVIDER_ID}/wares.json`)
+  const featured_services = configure_services({ data: wares?.ware_refs, path: '/services' })?.slice(0, 4)
+  const handleOnSubmit = ({ value }) => router.push({ pathname: '/browse', query: { q: value } }, '/browse')
 
-	return(
-		<>
+  if (isError) return <h1>Error...</h1>
+
+  return (
+    <>
       <Image
         alt='DNA chain'
         src={hero.src}
@@ -24,12 +28,18 @@ const Home = ({ services }) => {
       />
       <SearchBar onSubmit={handleOnSubmit} />
       <TitledTextBox title={TITLE} text={TEXT} />
-			<ItemGroup
-				items={featured_services}
-				withTitleLink={true}
-			/>
-		</>
-	)
+      {isLoading
+        ? (
+          <h1>Loading...</h1>
+        ) : (
+          <ItemGroup
+            items={featured_services}
+            withTitleLink={true}
+          />
+        )
+      }
+    </>
+  )
 }
 
 export default Home

--- a/services/fetcher.js
+++ b/services/fetcher.js
@@ -5,9 +5,7 @@ const defaultHeaders = { Authorization: `Bearer ${process.env.NEXT_PUBLIC_TOKEN}
 
 const a = axios.create({ baseURL, headers: defaultHeaders })
 
-export const fetcher = (str) => {
-
-  return a.get(str)
+export const fetcher = (...args) => {
+  return a.get(...args)
     .then(res => res.data)
-
 }

--- a/services/utils.js
+++ b/services/utils.js
@@ -1,0 +1,27 @@
+import useSWR from 'swr'
+import { fetcher } from './fetcher'
+
+export const useWares = (url) => {
+  const { data, error } = useSWR(url, fetcher)
+
+  return {
+    wares: data,
+    isLoading: !error && !data,
+    isError: error,
+  }
+}
+
+export const configure_services = ({ data, path }) => {
+  return data?.map(ware => {
+    return {
+      description: ware.snippet,
+      id: ware.reference_of_id,
+      img: {
+        src: ware.promo_image,
+        alt: `The promotional image for ${ware.name}`
+      },
+      name: ware.name,
+      href: `${path}/${ware.slug}`,
+    }
+  })
+}


### PR DESCRIPTION
# before this pr
we decided against using a global state manager like redux for this app because it didn't seem like we needed something that robust. plus, it might be a small anti pattern for next js. however, having to pass around data about each service through the router was becoming pretty painful and ugly

# with this pr
- we are using custom hooks that take advantage of the `useSWR` hook
- although we're using the same custom hook in multiple pages, the data is cached as long as the same url is passed
- moved the formation of our custom `services` variable into a function so it can be more easily accessed on multiple pages and DRY's the code
- account for when data is still loading or in an error state (actual components will be created for this with https://github.com/scientist-softserv/webstore-component-library/issues/24 and https://github.com/scientist-softserv/webstore-component-library/issues/25)

# demo
https://user-images.githubusercontent.com/29032869/200655672-5cefe579-0f3a-4169-8bd2-69e4a421333c.mp4

# resources
- https://swr.vercel.app/docs/getting-started#make-it-reusable