### PR TITLE
70-configure-statuses-for-requests-page

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -5,8 +5,13 @@ import { fetcher } from './fetcher'
 export const getAllRequests = () => {
   const { data, error } = useSWR(`/quote_groups/mine.json`, fetcher)
 
+  const all_requests = data?.quote_group_refs.map(quote_group => ({
+    ...quote_group,
+    status: configure_status(quote_group.status),
+  }))
+
   return {
-    all_requests: data?.quote_group_refs,
+    all_requests,
     isLoading: !error && !data,
     isError: error,
   }


### PR DESCRIPTION
# expected behavior
the statuses shown on "/requests" are also configured to follow the same rules as the statuses on individual request pages

# demo
- the browser shows the configured status
- the console array shows the original status
<img width="1393" alt="Screen Shot 2022-12-08 at 2 46 40 PM" src="https://user-images.githubusercontent.com/29032869/206565008-eed8c518-72a9-4064-b14b-6373b0822e23.png">
