### PR TITLE
64 new request pages

### DIFF
--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -1,6 +1,107 @@
-// TODO(alishaevn): redo this page when the time comes
+import React, { useState } from 'react'
+import { useRouter } from 'next/router'
+import {
+  AdditionalInfo,
+  BlankRequestForm,
+  Button,
+  ShippingDetails,
+  Title,
+} from 'webstore-component-library'
 // TODO(alishaevn): trying to access this page without being signed in should redirect to the login page
 
-const NewServiceRequest = () => <h1>This is a new request for a specific service.</h1>
+const NewServiceRequest = () => {
+  const router = useRouter()
+  const { ware } = router.query
+
+  const initialState = {
+    name: 'New Request',
+    billingSameAsShipping: false,
+    proposedDeadline: null,
+    billing: {
+      street: '',
+      street2: '',
+      city: '',
+      state: '',
+      zipCode: '',
+      country: '',
+      text: '',
+    },
+    shipping: {
+      street: '',
+      street2: '',
+      city: '',
+      state: '',
+      zipCode: '',
+      country: '',
+      text: '',
+    },
+    data: {
+      timeline: '',
+      description: '',
+      suppliersIdentified: 'Yes',
+    },
+    // TODO(alishaevn): how do we handle attachments?
+  }
+
+  const [requestForm, setRequestForm] = useState(initialState)
+
+  /**
+   * @param {object} event onChange event
+   * @param {string} property dot notated string representing the property in initialValue
+   * @returns {object} the updated component state
+   */
+  const updateRequestForm = (value, property) => {
+    const [initialProperty, nestedProperty] = property.split('.')
+
+    setRequestForm((currentState) => {
+      const updatedState = nestedProperty
+        ? { [initialProperty]: { ...requestForm[initialProperty], [nestedProperty]: value } }
+        : { [initialProperty]: value }
+
+      return {
+        ...currentState,
+        ...updatedState,
+      }
+    })
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    if (requestForm.billingSameAsShipping === true) {
+      Object.assign(requestForm.billing, requestForm.shipping)
+    }
+
+    // TODO(alishaevn): comment this back in when it's working
+    // createRequest(requestForm)
+  }
+
+  return(
+    <div className='container'>
+      <Title title={ware} addClass='my-4' />
+      <form onSubmit={handleSubmit} id='new-request-form'>
+        {/* TODO(alishaevn): add the dynamic form that's returned from the "initialize" endpoint */}
+        <div className='row'>
+          <div className='col'>
+            <ShippingDetails
+              billingCountry={requestForm.billing.country}
+              shippingCountry={requestForm.shipping.country}
+              updateRequestForm={updateRequestForm}
+            />
+          </div>
+          <div className='col'>
+            <AdditionalInfo updateRequestForm={updateRequestForm} />
+          </div>
+        </div>
+        <Button
+          backgroundColor='primary'
+          addClass='my-4 ms-auto d-block'
+          label='Initiate Request'
+          type='submit'
+          size='large'
+        />
+      </form>
+    </div>
+  )
+}
 
 export default NewServiceRequest

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -2,11 +2,12 @@ import React, { useState } from 'react'
 import { useRouter } from 'next/router'
 import {
   AdditionalInfo,
-  BlankRequestForm,
   Button,
   ShippingDetails,
   Title,
 } from 'webstore-component-library'
+// TODO(alishaevn): comment this back in when it's working
+// import { createRequest } from '../../../utils'
 // TODO(alishaevn): trying to access this page without being signed in should redirect to the login page
 
 const NewServiceRequest = () => {
@@ -38,6 +39,7 @@ const NewServiceRequest = () => {
     data: {
       timeline: '',
       description: '',
+      // TODO(alishaevn): does the api post function account for the supplier or does that need to be part of state?
       suppliersIdentified: 'Yes',
     },
     // TODO(alishaevn): how do we handle attachments?

--- a/pages/requests/new/index.js
+++ b/pages/requests/new/index.js
@@ -5,14 +5,93 @@ import { BlankRequestForm } from 'webstore-component-library'
 // https://assaydepot.slack.com/archives/C03FZDALABG/p1670605791891109
 
 const NewBlankRequest = () => {
-  // TODO(alishaevn): put a real function here that accepts our data and takes it to the post api call
-  const postRequestForm = (requestForm) => {
-    console.log({ requestForm })
+  const initialState = {
+    name: 'New Request',
+    billingSameAsShipping: false,
+    proposedDeadline: null,
+    billing: {
+      street: '',
+      street2: '',
+      city: '',
+      state: '',
+      zipCode: '',
+      country: '',
+      text: '',
+    },
+    shipping: {
+      street: '',
+      street2: '',
+      city: '',
+      state: '',
+      zipCode: '',
+      country: '',
+      text: '',
+    },
+    data: {
+      timeline: '',
+      description: '',
+      suppliersIdentified: 'Yes',
+    },
+    // TODO(alishaevn): how do we handle attachments?
   }
 
-  return (
+  const [requestForm, setRequestForm] = useState(initialState)
+
+  /**
+   * @param {object} event onChange event
+   * @param {string} property dot notated string representing the property in initialValue
+   * @returns {object} the updated component state
+   */
+  const updateRequestForm = (value, property) => {
+    const [initialProperty, nestedProperty] = property.split('.')
+
+    setRequestForm((currentState) => {
+      const updatedState = nestedProperty
+        ? { [initialProperty]: { ...requestForm[initialProperty], [nestedProperty]: value } }
+        : { [initialProperty]: value }
+
+      return {
+        ...currentState,
+        ...updatedState,
+      }
+    })
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    if (requestForm.billingSameAsShipping === true) {
+      Object.assign(requestForm.billing, requestForm.shipping)
+    }
+
+    // TODO(alishaevn): comment this back in when it's working
+    // createRequest(requestForm)
+  }
+
+  return(
     <div className='container'>
-      <BlankRequestForm onSubmit={requestForm => postRequestForm(requestForm)} />
+      <Title title='New Request' addClass='mt-4' />
+      <form onSubmit={handleSubmit} id='new-request-form'>
+        <BlankRequestForm updateRequestForm={updateRequestForm} />
+        <div className='row'>
+          <div className='col'>
+            <ShippingDetails
+              billingCountry={requestForm.billing.country}
+              shippingCountry={requestForm.shipping.country}
+              updateRequestForm={updateRequestForm}
+            />
+          </div>
+          <div className='col'>
+            <AdditionalInfo updateRequestForm={updateRequestForm} />
+          </div>
+        </div>
+        <Button
+          backgroundColor='primary'
+          addClass='my-4 ms-auto d-block'
+          label='Initiate Request'
+          type='submit'
+          size='large'
+        />
+      </form>
     </div>
   )
 }

--- a/pages/requests/new/index.js
+++ b/pages/requests/new/index.js
@@ -1,8 +1,12 @@
 import React from 'react'
 import { BlankRequestForm } from 'webstore-component-library'
+// TODO(alishaevn): comment this back in when it's working
+// import { createRequest } from '../../../utils'
 // TODO(alishaevn): trying to access this page without being signed in should redirect to the login page
+
 // TODO(alishaevn): come back to this page once the initialize api function has been created. re: the thread below
 // https://assaydepot.slack.com/archives/C03FZDALABG/p1670605791891109
+// we may wind up not needing this page at all if we have a default ware
 
 const NewBlankRequest = () => {
   const initialState = {
@@ -30,6 +34,7 @@ const NewBlankRequest = () => {
     data: {
       timeline: '',
       description: '',
+      // TODO(alishaevn): does the api post function account for the supplier or does that need to be part of state?
       suppliersIdentified: 'Yes',
     },
     // TODO(alishaevn): how do we handle attachments?


### PR DESCRIPTION
- create the new request forms in the webstore instead of in the library
- requires the [refactored blank request page](https://github.com/scientist-softserv/webstore-component-library/pull/102) from the library
- both request pages still exist because I'm a little unclear on how this `/make-a-request` api endpoint and default_ware value are going to work.