### PR TITLE
fix the ajv dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@rjsf/utils": "^5.0.0-beta.16",
     "@rjsf/validator-ajv8": "^5.0.0-beta.15",
     "@scientist-softserv/webstore-component-library": "^0.1.7",
+    "ajv": "^8.12.0",
     "axios": "^1.1.3",
     "bootstrap": "^5.2.3",
     "next": "12.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,7 +1407,7 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-"ajv8@npm:ajv@^8.11.0", ajv@^8.0.0:
+"ajv8@npm:ajv@^8.11.0", ajv@^8.0.0, ajv@^8.12.0:
   name ajv8
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"


### PR DESCRIPTION
# story
after merging the [CI code](https://github.com/scientist-softserv/webstore/pull/120) into the [request form pr](https://github.com/scientist-softserv/webstore/pull/119)...the request pages would no longer load. seems like the `ajv` dependency wasn't getting recognized anymore for some reason. rjsf worked before the CI code came in. idk for sure what about the ci code changed it.

one thing that may have been the cause is the following code was added to the `package.json` file. previously we were using node `v16.14.0`
``` js
"engines": {
    "node": "^19.2.0"
  }
```

<details>
<summary>pic of the ajv error</summary>

![Screen Shot 2023-01-16 at 6 55 45 PM](https://user-images.githubusercontent.com/29032869/212788167-1c3cadca-143c-452c-938e-a5df49cd786c.png)

</details>

# expected behavior
- install `ajv` as a full dependency so the new request page loads