### PR TITLE
ajv dependency pt2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "@rjsf/core": "^5.0.0-beta.15",
-    "@rjsf/utils": "^5.0.0-beta.16",
-    "@rjsf/validator-ajv8": "^5.0.0-beta.15",
+    "@rjsf/core": "^5.0.0-beta.17",
+    "@rjsf/utils": "^5.0.0-beta.17",
+    "@rjsf/validator-ajv8": "^5.0.0-beta.17",
     "@scientist-softserv/webstore-component-library": "^0.1.7",
-    "ajv": "^8.12.0",
     "axios": "^1.1.3",
     "bootstrap": "^5.2.3",
     "next": "12.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,20 +828,20 @@
     uncontrollable "^7.2.1"
     warning "^4.0.3"
 
-"@rjsf/core@^5.0.0-beta.15":
-  version "5.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.0.0-beta.15.tgz#3abe841bb9b3300a5dbe192bd99d936b572290c0"
-  integrity sha512-ihnrjwTjV+PgjeOtSae5ww2+etyiIp8qehjVS2A0HhDV3Whf2qwIML2aMXt3f4J1h/ch/IfQp20Q+ht2wWs9+A==
+"@rjsf/core@^5.0.0-beta.17":
+  version "5.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.0.0-beta.17.tgz#ac94dfa02b5b8d7155e3794436c47c14f028dd02"
+  integrity sha512-lzHtxgY53KjJBUalv7oXhepacHw7x8Ae+3i1n7dIqcU1TGPMBm5yhJF/8LIZsd09n5nmok0xGYujvRbGKmorXw==
   dependencies:
     lodash "^4.17.15"
     lodash-es "^4.17.15"
     nanoid "^3.3.4"
     prop-types "^15.7.2"
 
-"@rjsf/utils@^5.0.0-beta.16":
-  version "5.0.0-beta.16"
-  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.0.0-beta.16.tgz#c31c3750445491791a79f2cc1a0fe914896fadd1"
-  integrity sha512-dNQ620Q6a9cB28sjjRgJkxIuD9TFd03sNMlcZVdZOuZC6wjfGc4rKG0Lc7+xgLFvSPFKwXJprzfKSM3yuy9jXg==
+"@rjsf/utils@^5.0.0-beta.17":
+  version "5.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.0.0-beta.17.tgz#2265b59fef8e00b578cd7d882d108a49120526fb"
+  integrity sha512-FHDtyYX3D5Hs/TGxhIt9x+FmMOl3hC0+XU6ItCHK0hylwdyOMmRdfZQY182qbdfjVn1YZxxwyODNiUscVNBRkw==
   dependencies:
     json-schema-merge-allof "^0.8.1"
     jsonpointer "^5.0.1"
@@ -849,13 +849,13 @@
     lodash-es "^4.17.15"
     react-is "^18.2.0"
 
-"@rjsf/validator-ajv8@^5.0.0-beta.15":
-  version "5.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.0.0-beta.15.tgz#b63446613c3ea7819d6d61eacd8754f4ee0368fe"
-  integrity sha512-cBOepLoIFT7F6Pf2bZRndDyviWBXrwsUZROU1pBDGoAFuDTBZeXbMwOli9qLRf8KFaE3Lq5ddTiTGQDP4s3UAA==
+"@rjsf/validator-ajv8@^5.0.0-beta.17":
+  version "5.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.0.0-beta.17.tgz#590bf9358638363062c10176113fddd7cbc58c83"
+  integrity sha512-Dr8yQ3sh4jjI02o0jOB2Y1Hrn/v6rNYDV94vofeIh3P2heFJApunQeCzsK0xZz5kC/45gfTkosVlsNpIuwvN0Q==
   dependencies:
+    ajv "^8.11.0"
     ajv-formats "^2.1.1"
-    ajv8 "npm:ajv@^8.11.0"
     lodash "^4.17.15"
     lodash-es "^4.17.15"
 
@@ -1407,17 +1407,6 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-"ajv8@npm:ajv@^8.11.0", ajv@^8.0.0, ajv@^8.12.0:
-  name ajv8
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
-  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
@@ -1426,6 +1415,16 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.11.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-colors@^4.1.1:


### PR DESCRIPTION
related to #121 

# story
after merging the above pr, others who pulled down the latest code still got the same error I was getting then and couldn't build the app. at the time I added `ajv`, but this is a more complete fix and feels better. after the steps below I confirmed that I could still successfully run `yarn dev` and load both a blank and dynamic request form. I can also successfully run `yarn build`.

``` bash
# remove all rjsf packages AND ajv
yarn remove @rjsf/core @rjsf/utils @rjsf/validator-ajv8 ajv

# only reinstall the rsjf packages
yarn add @rjsf/core @rjsf/utils @rjsf/validator-ajv8
```