### PR TITLE
93 no proposed deadline

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -95,6 +95,7 @@ export const useCreateRequest = async ({ data, wareID }) => {
       name: data.name,
     },
     proposed_deadline_str: data.proposedDeadline,
+    no_proposed_deadline: data.proposedDeadline ? false : true,
     shipping_address_attributes: {
       city: data.shipping.city,
       country: data.shipping.country,

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -138,7 +138,7 @@ export const useInitializeRequest = (id) => {
 
   return {
     dynamicForm,
-    isLoadingInitialRequest: !error && !dynamicForm,
+    isLoadingInitialRequest: !error && !data,
     isInitialRequestError: error,
   }
 }


### PR DESCRIPTION
- stop showing the blank request form before the dynamic one loads
- when the user checks the box that says there isn't a proposed deadline the following is sent as part of the api `create` call
  ``` js
  no_proposed_deadline: true
  proposed_deadline_str: ""
  ```

# demo
<img width="650" alt="image" src="https://user-images.githubusercontent.com/29032869/213371908-7701f26b-28c6-4498-8dcb-476decce668f.png">
