### PR TITLE
131 hide featured service page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -11,6 +11,7 @@ import {
   configureErrors,
   configureServices,
   useAllWares,
+  FEATURED_SERVICE_PATH,
   TEXT,
   TITLE,
 } from '../utils'
@@ -18,7 +19,7 @@ import {
 const Home = () => {
   const router = useRouter()
   const { wares, isLoading, isError } = useAllWares()
-  const featuredServices = configureServices({ data: wares, path: '/services' })?.slice(0, 3)
+  const featuredServices = configureServices({ data: wares, path: FEATURED_SERVICE_PATH })?.slice(0, 3)
   const handleOnSubmit = ({ value }) => router.push(
     { pathname: '/browse', query: { q: value } },
     (value.length > 0 ? `/browse?q=${value}` : '/browse')

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -98,3 +98,9 @@ export const NAVIGATION_LINKS = [
     path: '/requests',
   },
 ]
+
+// updates the title link on the featured service cards on the homepage.
+// 'requests/new' will link to a new request for that service
+// change this to '/services' to have this link to a page for an individual service.
+// if you choose to go this route, you can update the content for the service's page at pages/services/[ware].js
+export const FEATURED_SERVICE_PATH = '/requests/new'


### PR DESCRIPTION
# summary
- changes the path on the featured service page to point to the new request page for that service
- adds a constant for that path & comments of how to use the service page instead if the user decides