### PR TITLE
139 faster message viewing

### DIFF
--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { useRouter } from 'next/router'
 import {
   ActionsGroup,
@@ -26,7 +27,7 @@ const Request = () => {
   const { id } = router.query
   const { request, isLoadingRequest, isRequestError } = useOneRequest(id)
   const { allSOWs, isLoadingSOWs, isSOWError } = useAllSOWs(id, request?.identifier)
-  const { messages, isLoadingMessages, isMessagesError } = useAllMessages(id)
+  const { messages, isLoadingMessages, isMessagesError, mutate, data } = useAllMessages(id)
   const documents = (allSOWs) ? [...allSOWs] : []
 
   const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingMessages
@@ -36,7 +37,10 @@ const Request = () => {
 
   if (isError) return <Error errors={configureErrors([isRequestError, isSOWError, isMessagesError])} router={router} />
 
-  const handleSendingMessages = ({ message, files }) => sendMessage({ id, message, files })
+  const handleSendingMessages = ({ message, files }) => {
+    sendMessage({ id, message, files })
+    mutate({ ...data, ...messages })
+  }
 
   return(
     <div className='container'>

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -52,12 +52,14 @@ export const useAllSOWs = (id, requestIdentifier) => {
 }
 
 export const useAllMessages = (id) => {
-  const { data, error } = useSWR(`/quote_groups/${id}/notes.json`, fetcher, { refreshInterval: 300 })
+  const { data, error, mutate } = useSWR(`/quote_groups/${id}/notes.json`, fetcher)
   let messages
   if (data) messages = configureMessages(data.notes)
 
   return {
+    data,
     messages,
+    mutate,
     isLoadingMessages: !error && !data,
     isMessageError: error,
   }

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -52,7 +52,7 @@ export const useAllSOWs = (id, requestIdentifier) => {
 }
 
 export const useAllMessages = (id) => {
-  const { data, error } = useSWR(`/quote_groups/${id}/notes.json`, fetcher)
+  const { data, error } = useSWR(`/quote_groups/${id}/notes.json`, fetcher, { refreshInterval: 300 })
   let messages
   if (data) messages = configureMessages(data.notes)
 


### PR DESCRIPTION
# summary
- uses SWR mutate to make the messages update after a new message is submitted

# video
https://share.getcloudapp.com/Z4umNGzb

# acceptance criteria
- [ ] messages update more quickly in ~10s vs. taking 50s to a minute per message

# notes
- the messages are still not instant- just faster, possibly due to the api calls lagging a little bit. if these messages needed to update in near-real time, we could use the [refreshInterval setting of useSWR](https://swr.vercel.app/docs/revalidation#revalidate-on-interval)- we decided not to go this route since it would force api calls every few seconds, and since this is not a chat feature, it was not deemed necessary to have completely instantaneous updates