### PR TITLE
128 - get attachments working

### DIFF
--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -13,7 +13,7 @@ import {
 } from '@scientist-softserv/webstore-component-library'
 import {
   configureErrors,
-  sendMessage,
+  postMessageOrAttachment,
   useAllMessages,
   useAllSOWs,
   useOneRequest,
@@ -36,7 +36,7 @@ const Request = () => {
 
   if (isError) return <Error errors={configureErrors([isRequestError, isSOWError, isMessagesError])} router={router} />
 
-  const handleSendingMessages = ({ message, files }) => sendMessage({ id, message, files })
+  const handleSendingMessages = ({ message, files }) => postMessageOrAttachment({ id, message, files })
 
   return(
     <div className='container'>

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -65,7 +65,14 @@ export const useAllMessages = (id) => {
 
 export const postMessageOrAttachment = ({ id, message, files }) => {
   /* eslint-disable camelcase */
+
+  // in the scientist marketplace, both user messages sent on a request's page and
+  // attachments to a request of any kind are considered "notes"
+  // only user messages will have a body, attachments to requests will not.
+  // only attachments that are added when creating a new request should have a title & status.
   const note = {
+    title: message ? null : "New Attachment",
+    status: message ? null : "Other File",
     body: message || null,
     quoted_ware_ids: [id],
     data_files: files,

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -63,10 +63,10 @@ export const useAllMessages = (id) => {
   }
 }
 
-export const sendMessage = ({ id, message, files }) => {
+export const postMessageOrAttachment = ({ id, message, files }) => {
   /* eslint-disable camelcase */
   const note = {
-    body: message,
+    body: message || null,
     quoted_ware_ids: [id],
     data_files: files,
   }
@@ -123,6 +123,7 @@ export const createRequest = async ({ data, wareID }) => {
   }
 
   const response = await posting(`/wares/${wareID}/quote_groups.json`, { pg_quote_group })
+  postMessageOrAttachment({id: response.requestID, files: data.attachments})
   return response
   /* eslint-enable camelcase */
 }


### PR DESCRIPTION
## summary
- handles attachments on the request form
- renames sendMessage to postMessageOrAttachment because the notes endpoint is used for both request messages & request attachments

## video
creating a request, and then checking the notes endpoint to make sure the attachments are there
https://share.getcloudapp.com/Z4um9bLb

## acceptance criteria
- [ ] as a user, I can upload an attachment to a request and it is submitted on the new request form

## notes
included this info in a comment as well to further explain how "notes" are used:
- in the scientist marketplace, both user messages sent on a request's page and attachments to a request of any kind are referred to as "notes"
- only user messages will have a `body`, attachments to requests will not.
- only attachments that are added when creating a new request should have a `title` & `status`.