### PR TITLE
132 restrict request routes

### DIFF
--- a/pages/browse/index.js
+++ b/pages/browse/index.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { useSession } from 'next-auth/react'
-import { Error, Item, SearchBar } from '@scientist-softserv/webstore-component-library'
+import { Item, Notice, SearchBar } from '@scientist-softserv/webstore-component-library'
 import { configureErrors, configureServices, useFilteredWares } from '../../utils'
 
 const Browse = () => {
@@ -21,7 +21,19 @@ const Browse = () => {
     return router.push({ pathname: '/browse', query: { q: value } }, (value.length > 0 ? `/browse?q=${value}` : '/browse'))
   }
 
-  if (isError) return <Error errors={configureErrors([isError])} router={router} />
+  if (isError) {
+    return (
+      <Notice
+        alert={configureErrors([isError])}
+        dismissible={false}
+        withBackButton={true}
+        buttonProps={{
+          onClick: () => router.back(),
+          text: 'Click to return to the previous page.',
+        }}
+      />
+    )
+  }
 
   return (
     <div className='container'>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router'
 import { useSession } from 'next-auth/react'
 import {
-  Error,
   Image,
   ItemGroup,
+  Notice,
   SearchBar,
   TitledTextBox,
 } from '@scientist-softserv/webstore-component-library'
@@ -40,7 +40,10 @@ const Home = () => {
         <SearchBar onSubmit={handleOnSubmit} />
         <TitledTextBox title={TITLE} text={TEXT} />
         {isError ? (
-          <Error errors={configureErrors([isError])} router={router} showBackButton={false} canDismissAlert={true} />
+          <Notice
+            alert={configureErrors([isError])}
+            withBackButton={false}
+          />
         ) : (
           <>
             <ItemGroup

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -65,12 +65,12 @@ const Request = () => {
 
   // TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
   // const handleSendingMessages = ({ message, files }) => {
-    // postMessageOrAttachment({
-    //   id,
-    //   message,
-    //   files,
-    //   accessToken: session?.accessToken,
-    // })
+  //   postMessageOrAttachment({
+  //     id,
+  //     message,
+  //     files,
+  //     accessToken: session?.accessToken,
+  //   })
   //   mutate({ ...data, ...messages })
   // }
 

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -5,9 +5,9 @@ import {
   ActionsGroup,
   CollapsibleSection,
   Document,
-  Error,
   Loading,
   Messages,
+  Notice,
   RequestStats,
   StatusBar,
   TextBox,
@@ -34,23 +34,34 @@ const Request = () => {
   const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingMessages
   const isError = isRequestError || isSOWError || isMessagesError
 
-  // TODO(alishaevn): update the return value after https://github.com/scientist-softserv/webstore-component-library/issues/136 is completed
-  // if (!session) {
-  //   return (
-  //     <Error
-  //       errors={{
-  //         errorText: ['Please log in to view this request.'],
-  //         errorTitle: 'Unauthorized',
-  //         variant: 'info'
-  //       }}
-  //       router={router}
-  //       showBackButton={false}
-  //     />)
-  // }
+  if (!session) {
+    return (
+      <Notice
+        alert={{
+          body: ['Please log in to view this request.'],
+          title: 'Unauthorized',
+          variant: 'info'
+        }}
+        dismissible={false}
+      />
+    )
+  }
 
   if (isLoading) return <Loading wrapperClass='item-page mt-5' />
 
-  if (isError) return <Error errors={configureErrors([isRequestError, isSOWError, isMessagesError])} router={router} />
+  if (isError) {
+    return (
+      <Notice
+        alert={configureErrors([isRequestError, isSOWError, isMessagesError])}
+        dismissible={false}
+        withBackButton={true}
+        buttonProps={{
+          onClick: () => router.back(),
+          text: 'Click to return to the previous page.',
+        }}
+      />
+    )
+  }
 
   // TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
   // const handleSendingMessages = ({ message, files }) => {
@@ -63,12 +74,13 @@ const Request = () => {
   //   mutate({ ...data, ...messages })
   // }
 
-  return(
+  return (
     <div className='container'>
-      <StatusBar statusArray={STATUS_ARRAY} apiRequestStatus={request.status.text} addClass='mt-4'/>
+      <StatusBar statusArray={STATUS_ARRAY} apiRequestStatus={request.status.text} addClass='mt-4' />
       <div className='row mb-4'>
         <div className='col-sm-4 col-md-3 mt-2 mt-sm-4 order-1 order-sm-0'>
-          {/* // TODO(alishaevn): return the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided */}
+          {/* // TODO(alishaevn): return the below once the direction of
+          https://github.com/scientist-softserv/webstore/issues/156 has been decided */}
           {/* <ActionsGroup handleSendingMessages={handleSendingMessages}/> */}
           <div className='mt-3'>
             <RequestStats

--- a/pages/requests/index.js
+++ b/pages/requests/index.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/router'
 import {
-  Error,
   LinkedButton,
   Loading,
+  Notice,
   RequestList,
 } from '@scientist-softserv/webstore-component-library'
 import {
@@ -22,23 +22,36 @@ const Requests = () => {
   const isError = isAllRequestsError || isDefaultWareError
   const isLoading = isLoadingAllRequests || isLoadingDefaultWare
 
-  // TODO(alishaevn): update the return value after https://github.com/scientist-softserv/webstore-component-library/issues/136 is completed
-  // if (!session) {
-  //   return (
-  //     <Error
-  //       errors={{
-  //         errorText: ['Please log in to make new requests or view existing ones.'],
-  //         errorTitle: 'Unauthorized',
-  //         variant: 'info'
-  //       }}
-  //       router={router}
-  //       showBackButton={false}
-  //     />)
-  // }
+  // Check whether the user is authenticated first. If it does, we can return the API errors if applicable.
+  if (!session) {
+    return (
+      <Notice
+        alert={{
+          body: ['Please log in to make new requests or view existing ones.'],
+          title: 'Unauthorized',
+          variant: 'info'
+        }}
+        dismissible={false}
+        withBackButton={false}
+      />
+    )
+  }
 
   if (isLoading) return <Loading wrapperClass='mt-5' />
 
-  if (isError) return <Error errors={configureErrors([isAllRequestsError, isDefaultWareError])} router={router} />
+  if (isError) {
+    return (
+      <Notice
+        alert={configureErrors([isAllRequestsError, isDefaultWareError])}
+        dismissible={false}
+        withBackButton={true}
+        buttonProps={{
+          onClick: () => router.back(),
+          text: 'Click to return to the previous page.',
+        }}
+      />
+    )
+  }
 
   return (
     <div className='container'>

--- a/pages/requests/index.js
+++ b/pages/requests/index.js
@@ -32,7 +32,6 @@ const Requests = () => {
           variant: 'info'
         }}
         dismissible={false}
-        withBackButton={false}
       />
     )
   }

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -8,8 +8,8 @@ import {
   AdditionalInfo,
   BlankRequestForm,
   Button,
-  Error,
   Loading,
+  Notice,
   ShippingDetails,
   Title,
 } from '@scientist-softserv/webstore-component-library'
@@ -112,23 +112,35 @@ const NewRequest = () => {
   }, [requestSucceeded, requestErred, requestID])
 
   // TODO(alishaevn): update the return value after https://github.com/scientist-softserv/webstore-component-library/issues/136 is completed
-  // if (!session) {
-  //   return (
-  //     <Error
-  //       errors={{
-  //         errorText: ['Please log in to make new requests.'],
-  //         errorTitle: 'Unauthorized',
-  //         variant: 'info'
-  //       }}
-  //       router={router}
-  //       showBackButton={false}
-  //     />)
-  // }
+  if (!session) {
+    return (
+      <Notice
+        alert={{
+          body: ['Please log in to make new requests.'],
+          title: 'Unauthorized',
+          variant: 'info'
+        }}
+        dismissible={false}
+      />
+    )
+  }
 
-    // TODO(alishaevn): use react bs placeholder component
-    if (isLoadingInitialRequest || !wareID) return <Loading wrapperClass='item- mt-5' />
+  // TODO(alishaevn): use react bs placeholder component
+  if (isLoadingInitialRequest || !wareID) return <Loading wrapperClass='item- mt-5' />
 
-    if (isInitialRequestError) return <Error errors={configureErrors([isInitialRequestError])} router={router} />
+  if (isInitialRequestError) {
+    return (
+      <Notice
+        alert={configureErrors([isInitialRequestError])}
+        dismissible={false}
+        withBackButton={true}
+        buttonProps={{
+          onClick: () => router.back(),
+          text: 'Click to return to the previous page.',
+        }}
+      />
+    )
+  }
 
   return(
     <div className='container'>

--- a/pages/services/[ware].js
+++ b/pages/services/[ware].js
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import { useSession } from 'next-auth/react'
-import { Error, ItemPage, Loading } from '@scientist-softserv/webstore-component-library'
+import { ItemPage, Notice, Loading } from '@scientist-softserv/webstore-component-library'
 import { configureErrors, DEFAULT_WARE_IMAGE, useOneWare } from '../../utils'
 
 const Service = () => {
@@ -9,26 +9,32 @@ const Service = () => {
   const { id } = router.query
   const { ware, isLoading, isError } = useOneWare(id, session?.accessToken)
 
-  if (isError) return <Error errors={configureErrors([isError])} router={router} />
+  if (isLoading) return <Loading wrapperClass='item-page mt-5' />
+
+  if (isError) {
+    return (
+      <Notice
+        alert={configureErrors([isError])}
+        dismissible={false}
+        withBackButton={true}
+        buttonProps={{
+          onClick: () => router.back(),
+          text: 'Click to return to the previous page.',
+        }}
+      />
+    )
+  }
 
   return (
-    <>
-      {isLoading
-        ? (
-          <Loading wrapperClass='item-page mt-5' />
-        ) : (
-          <ItemPage
-            img={
-              ware.urls.promo_image ? {
-                src: ware.urls.promo_image,
-                alt: `The promotional image for ${ware.name}`,
-              } : DEFAULT_WARE_IMAGE
-            }
-            ware={ware}
-          />
-        )
+    <ItemPage
+      img={
+        ware.urls.promo_image ? {
+          src: ware.urls.promo_image,
+          alt: `The promotional image for ${ware.name}`,
+        } : DEFAULT_WARE_IMAGE
       }
-    </>
+      ware={ware}
+    />
   )
 }
 

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -1,11 +1,11 @@
 import { DEFAULT_WARE_IMAGE } from '../constants'
 import { statusColors } from '../theme'
 import {
-  normalizeDescription, 
-  normalizeHtmlDescription, 
+  normalizeDescription,
+  normalizeHtmlDescription,
   normalizeDate,
   timeSince,
-  formatBytes 
+  formatBytes
 } from '../helpers'
 
 export const configureServices = ({ data, path }) => {
@@ -63,20 +63,19 @@ export const configureRequests = ({ data, path }) => {
 // takes an array of errors for each page or component
 export const configureErrors = (errors) => {
   const env = process.env.NODE_ENV
-  let errorText = []
-  let errorTitle = ''
   const remainingErrors = errors.filter(error => error)
-  
+  let body = []
+  let title = ''
+
   if (env === 'development') {
     remainingErrors.map(error => {
-      errorText.push(JSON.stringify(error))
-      errorTitle = remainingErrors.length > 1 ? 'There were multiple errors.' : error.name
-      return { errorText, errorTitle }
+      body.push(JSON.stringify(error, null, 2))
+      title = remainingErrors.length > 1 ? 'There were multiple errors.' : error.name
     })
 
     return {
-      errorText: errorText, // returns an array that will be mapped over in the component
-      errorTitle: errorTitle,
+      body, // returns an array that will be mapped over in the component
+      title,
       variant: 'warning'
     }
   }
@@ -89,14 +88,14 @@ export const configureErrors = (errors) => {
     case 404:
       text = 'This page or section was not found.'
       break
-    
+
     default:
       text = "We're working on getting this back up and running as soon as possible."
     }
 
     return {
-      errorText: [text],
-      errorTitle: "We're sorry - something went wrong.",
+      body: [text],
+      title: "We're sorry - something went wrong.",
       variant: 'danger'
     }
   }

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -65,7 +65,7 @@ export const useAllMessages = (id, accessToken) => {
   }
 }
 
-  // TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
+// TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
 export const postMessageOrAttachment = ({ id, message, files, accessToken }) => {
   /* eslint-disable camelcase */
 
@@ -74,8 +74,8 @@ export const postMessageOrAttachment = ({ id, message, files, accessToken }) => 
   // only user messages will have a body, attachments to requests will not.
   // only attachments that are added when creating a new request should have a title & status.
   const note = {
-    title: message ? null : "New Attachment",
-    status: message ? null : "Other File",
+    title: message ? null : 'New Attachment',
+    status: message ? null : 'Other File',
     body: message || null,
     quoted_ware_ids: [id],
     data_files: files,
@@ -206,7 +206,7 @@ export const dynamicFormSchema = (defaultSchema) => {
 }
 
 export const useDefaultWare = (accessToken) => {
-  const { data, error } = useSWR([`/wares.json?q=make-a-request`, accessToken])
+  const { data, error } = useSWR([`/wares.json?q=make-a-request`, accessToken], fetcher)
 
   return {
     defaultWareID: data?.ware_refs?.[0]?.id.toString(),

--- a/utils/api/services.js
+++ b/utils/api/services.js
@@ -11,7 +11,9 @@ export const useAllWares = (accessToken) => {
 }
 
 export const useFilteredWares = (query, accessToken) => {
-  const { data, error } = useSWR(accessToken ? [`/providers/${process.env.NEXT_PUBLIC_PROVIDER_ID}/wares.json?q=${query}`, accessToken] : null)
+  // This function has "url" separated to avoid a linting line length error
+  const url = accessToken ? [`/providers/${process.env.NEXT_PUBLIC_PROVIDER_ID}/wares.json?q=${query}`, accessToken] : null
+  const { data, error } = useSWR(url)
 
   return {
     wares: data?.ware_refs,


### PR DESCRIPTION
# Story
We are using the more reusable `Notice` component to render our errors and other alerts.

_after I pulled in main...every api request stays in "loading". this is because the url being used in all of our `swr` functions remains at null, instead of updating when the access token or other property is defined. I'll handle that in a different ticket._

_ticket related to the above issue: https://github.com/scientist-softserv/webstore/pull/159_
_new ticket to handle the above issue: https://github.com/scientist-softserv/webstore/issues/161_ 

# Demo
|"/" | "/requests" |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/29032869/215129421-719cad76-703e-4c73-8ba4-3da33497f85d.png) | ![image](https://user-images.githubusercontent.com/29032869/215129708-e2be9f6e-9692-491d-84e9-eb5a645a06ee.png) |