### PR TITLE
139 add variables to theme map

### DIFF
--- a/utils/theme/theme.module.scss
+++ b/utils/theme/theme.module.scss
@@ -10,6 +10,18 @@ $light: #f8f9fa;
 $dark: #212529;
 $white: #ffffff;
 
+// these imports must be AFTER the theme color overrides above in order to properly override bootstrap's colors, but before the theme maps.
+@import "../../node_modules/bootstrap/scss/functions";
+@import "../../node_modules/bootstrap/scss/variables";
+@import "../../node_modules/bootstrap/scss/mixins";
+
+// create our own custom colors map, and merge it with bootstrap's theme-colors map to generate utility functions that can be used throughout the map
+$custom-colors: (
+  "light-2": darken($light, 3%),
+  "light-3": darken($light, 10%)
+);
+$theme-colors: map-merge($theme-colors, $custom-colors);
+
 
 // these variables are also exported for use in variables.js
 :export {


### PR DESCRIPTION
# story
adds 2 variables to the theme map for use throughout the app. utility classes for these colors will be automatically generated by bootstrap (for example, we can now use bg-light-2)

# related
https://github.com/scientist-softserv/webstore-component-library/issues/139
Component Library PR: https://github.com/scientist-softserv/webstore-component-library/pull/140
