### PR TITLE
67 without authenticated user

### DIFF
--- a/.env
+++ b/.env
@@ -1,13 +1,6 @@
 # reference https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser
 # to learn about the NEXT_PUBLIC prefix
 
-NEXT_PUBLIC_DOMAIN_NAME=acme
+NEXT_PUBLIC_PROVIDER_NAME=acme
 NEXT_PUBLIC_PROVIDER_ID=572
-
-# values to use for acme-staging
-# NEXT_PUBLIC_DOMAIN_NAME=acme-staging
-# NEXT_PUBLIC_PROVIDER_ID=608
-
 NEXT_PUBLIC_SCIENTIST_API_VERSION=v2
-NEXT_PUBLIC_PROVIDER_NAME=Acme
-

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 ## Table of Contents
 
 - [Getting Started](#getting-started)
-  - [Configure token to pull from the github npm repository](#configure-token-to-pull-from-the-github-npm-repository)
-  - [Component Library Dev Mode](#component-library-dev-mode)
-  - [Authentication](#authentication)
-    - [User Credentials](#user-credentials)
-    - [Provider Credentials](#provider-credentials)
+  - [Webstore Component Library](#webstore-component-library)
+    - [Configure token to pull from the github npm repository](#configure-token-to-pull-from-the-github-npm-repository)
+    - [Component Library Dev Mode](#component-library-dev-mode)
+  - [Environment Variables](#environment-variables)
+    - [Authentication](#authentication)
+      - [User Credentials](#user-credentials)
+      - [Provider Credentials](#provider-credentials)
 - [Linting](#linting)
 - [Testing](#testing)
   - [Jest](#jest)
@@ -29,17 +31,17 @@
 
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages. -->
 
-### Configure token to pull from the github npm repository
+### Webstore Component Library
+The webstore requires a [React component library](https://reactjs.org/docs/react-component.html) of view components. That dependency is packaged and released independently and we fetch it from the github repository.
 
-The webstore depends on a library of view components. That dependency is packaged and released independently and we fetch it from
-the github npm repository, which in turn requires an auth token to pull
+#### Configure token to pull from the github npm repository
+Using the published github npm package requires an auth token to pull:
 
-  1. Create classic token on your github account https://github.com/settings/tokens
+  1. Create a classic token on your github account https://github.com/settings/tokens
   2. `echo "//npm.pkg.github.com/:_authToken=$THE_ABOVE_TOKEN_GOES_HERE" >> ~/.npmrc`
 
-### Component Library Dev Mode
-
-The webstore requires a [React component library](https://reactjs.org/docs/react-component.html), you must manually clone the component library to your computer, build, and link it:
+#### Component Library Dev Mode
+Using the local github repository requires you to manually clone the component library to your computer, build, and link it:
 
 Preparing your local copy of the component library:
 
@@ -61,21 +63,30 @@ and your `webstore` will start using the local component build.
 
 If you are using a local version of the component library, you will need to temporarily delete the line `"@scientist-softserv/webstore-component-library": "VERSION_HERE",` from the `package.json` file in order to see your local changes as opposed to pulling from the github package.
 
-### Authentication
-All API endpoints in this app require some form of authentication. A logged out user will be able to access the home and browse pages using a provider credential, while a logged in user can access all pages using their own credentials.
+### Environment Variables
+Configure the environment variables below in your local and published application to ensure that it works.
 
-#### User Credentials
-Please add the following ENV variables to your application locally and in production.
-
-_In local development, place the `NEXTAUTH_SECRET`, `CLIENT_ID` and `CLIENT_SECRET` in a ".env.local" file so that it is git ignored._
+#### Provider
+Someone with access to the api needs to visit `/providers.json?q=${YOUR_PROVIDER_NAME}` to find your provider object and id. Once found, update the variable below.
 
 ``` bash
+# .env
 NEXT_PUBLIC_PROVIDER_NAME # e.g.: acme
-NEXTAUTH_SECRET # create this by running `openssl rand -base64 32` in your terminal
-CLIENT_ID # retrieved from the supplier storefront
-CLIENT_SECRET # retrieved from the supplier storefront
+NEXT_PUBLIC_PROVIDER_ID # e.g.: 500
 ```
-#### Provider Credentials
+
+#### Authentication
+All API endpoints in this app require some form of authentication. A logged out user will be able to access the home and browse pages using a provider credential, while a logged in user can access all pages using their own credentials.
+
+##### User Credentials
+``` bash
+# .env.local
+NEXTAUTH_SECRET # create this by running `openssl rand -base64 32` in your terminal
+CLIENT_ID # retrieved from the provider storefront
+CLIENT_SECRET # retrieved from the provider storefront
+```
+
+##### Provider Credentials
 Please run the following in your terminal:
 ``` bash
 # When replacing the variables below with your actual values,
@@ -84,10 +95,14 @@ echo -n 'CLIENT_ID:CLIENT_SECRET' | base64
 
 # Plug that string into the following line of code, replacing the all caps values with your actual values
 curl -X POST -H 'Authorization: Basic THISISAREALLYLONGALPHANUMERICSTRING' -d 'grant_type=client_credentials' https://NEXT_PUBLIC_PROVIDER_NAME.scientist.com/oauth/token/
-
 ```
 
-The curl command will return a JSON object that has an `access_token` property. Store the value of that property as the `NEXT_PUBLIC_TOKEN` ENV variable in your ".env.local" file and in your production environment.
+The curl command will return a JSON object that has an `access_token` property. Store the value of that property as shown below:
+
+``` bash
+# .env.local
+NEXT_PUBLIC_TOKEN
+```
 
 ## Linting
 ``` bash

--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 ## Table of Contents
 
 - [Getting Started](#getting-started)
-- [Using the component library](#using-the-component-library)
-  - [In its development mode](#in-its-development-mode)
-  - [In its production mode](#In-its-production-mode)
+  - [Configure token to pull from the github npm repository](#configure-token-to-pull-from-the-github-npm-repository)
+  - [Component Library Dev Mode](#component-library-dev-mode)
+  - [Authentication](#authentication)
+    - [User Credentials](#user-credentials)
+    - [Provider Credentials](#provider-credentials)
 - [Linting](#linting)
+- [Testing](#testing)
+  - [Jest](#jest)
+  - [Cypress](#cypress)
 
 ---
 
@@ -56,7 +61,35 @@ and your `webstore` will start using the local component build.
 
 If you are using a local version of the component library, you will need to temporarily delete the line `"@scientist-softserv/webstore-component-library": "VERSION_HERE",` from the `package.json` file in order to see your local changes as opposed to pulling from the github package.
 
-# Linting
+### Authentication
+All API endpoints in this app require some form of authentication. A logged out user will be able to access the home and browse pages using a provider credential, while a logged in user can access all pages using their own credentials.
+
+#### User Credentials
+Please add the following ENV variables to your application locally and in production.
+
+_In local development, place the `NEXTAUTH_SECRET`, `CLIENT_ID` and `CLIENT_SECRET` in a ".env.local" file so that it is git ignored._
+
+``` bash
+NEXT_PUBLIC_PROVIDER_NAME # e.g.: acme
+NEXTAUTH_SECRET # create this by running `openssl rand -base64 32` in your terminal
+CLIENT_ID # retrieved from the supplier storefront
+CLIENT_SECRET # retrieved from the supplier storefront
+```
+#### Provider Credentials
+Please run the following in your terminal:
+``` bash
+# When replacing the variables below with your actual values,
+# the following code should return something like: THISISAREALLYLONGALPHANUMERICSTRING
+echo -n 'CLIENT_ID:CLIENT_SECRET' | base64
+
+# Plug that string into the following line of code, replacing the all caps values with your actual values
+curl -X POST -H 'Authorization: Basic THISISAREALLYLONGALPHANUMERICSTRING' -d 'grant_type=client_credentials' https://NEXT_PUBLIC_PROVIDER_NAME.scientist.com/oauth/token/
+
+```
+
+The curl command will return a JSON object that has an `access_token` property. Store the value of that property as the `NEXT_PUBLIC_TOKEN` ENV variable in your ".env.local" file and in your production environment.
+
+## Linting
 ``` bash
 # lint all files
 yarn lint
@@ -65,11 +98,11 @@ yarn lint
 yarn lint --fix
 ```
 
-# Testing
+## Testing
 
 This project uses both Cypress and Jest for testing.
 
-## Jest
+### Jest
 
 To run all jest tests for files you have changed, run
 ```
@@ -84,7 +117,7 @@ yarn test-watch
 
 and press `a`
 
-## Cypress
+### Cypress
 Cypress is an desktop application that runs on your computer. Cypress is already installed on this project, but your machine will need to meet certain [system requirements](https://docs.cypress.io/guides/getting-started/installing-cypress#System-requirements) to run the Cypress application.
 
 If you meet the requirements in the Cypress docs, you can run the `yarn run cypress open` command to start Cypress. from the Cypress desktop app, you will be able to create and run tests.

--- a/utils/api/base.js
+++ b/utils/api/base.js
@@ -1,17 +1,13 @@
 import axios from 'axios'
 
 const baseURL = `https://${process.env.NEXT_PUBLIC_DOMAIN_NAME}.scientist.com/api/${process.env.NEXT_PUBLIC_SCIENTIST_API_VERSION}`
-// TODO(alishaevn): delete or reinstate the defaultHeaders variable and use case after we determine how to handle an authenticated user.
-// const defaultHeaders = { Authorization: `Bearer ${process.env.NEXT_PUBLIC_TOKEN}` }
-
-// const api = axios.create({ baseURL, headers: defaultHeaders })
+// Use the user's own access token if they are signed in. If not, fall back to the access token provided through the provider credentials
+const defaultHeaders = (token) => ({ Authorization: `Bearer ${token || process.env.NEXT_PUBLIC_TOKEN}` })
 const api = axios.create({ baseURL })
 
 export const fetcher = (url, token) => {
   try {
-    const headers = { Authorization: `Bearer ${token}` }
-
-    return api.get(url, { headers })
+    return api.get(url, { headers: defaultHeaders(token) })
       .then(res => res.data)
   } catch (error) {
     // TODO(alishaevn): handle the error when sentry is set up
@@ -20,10 +16,8 @@ export const fetcher = (url, token) => {
 }
 
 export const posting = async (url, data, token) => {
-  const headers = { Authorization: `Bearer ${token}` }
-
   try {
-    const response = await api.post(url, data, { headers })
+    const response = await api.post(url, data, { headers: defaultHeaders(token) })
 
     if (response.data.id) {
       return {

--- a/utils/api/base.js
+++ b/utils/api/base.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-const baseURL = `https://${process.env.NEXT_PUBLIC_DOMAIN_NAME}.scientist.com/api/${process.env.NEXT_PUBLIC_SCIENTIST_API_VERSION}`
+const baseURL = `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/api/${process.env.NEXT_PUBLIC_SCIENTIST_API_VERSION}`
 // Use the user's own access token if they are signed in. If not, fall back to the access token provided through the provider credentials
 const defaultHeaders = (token) => ({ Authorization: `Bearer ${token || process.env.NEXT_PUBLIC_TOKEN}` })
 const api = axios.create({ baseURL })

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -143,7 +143,7 @@ export const configureMessages = (data) => {
     attachments: note.attachments.map((attachment) => ({
       ...attachment,
       contentLength: formatBytes(attachment.content_length),
-      href: `https://${process.env.NEXT_PUBLIC_DOMAIN_NAME}.scientist.com/secure_attachments/${attachment.uuid}`
+      href: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/secure_attachments/${attachment.uuid}`
     })) || [],
   }))
 }


### PR DESCRIPTION
# story
a non logged in user ought to still be able to access the "/" and "browse" routes.

# expected behavior
- add the supplier credentials as a fallback if the user is not signed in

# notes
the following was removed from the `.env` file in favor of the `.env.local` file.
``` bash
# values to use for acme-staging
# NEXT_PUBLIC_PROVIDER_NAME=acme-staging
# NEXT_PUBLIC_PROVIDER_ID=608
```

# resources
- https://assaydepot.slack.com/archives/C03FZDALABG/p1669679901998389?thread_ts=1669679800.623529&cid=C03FZDALABG
- https://www.rubydoc.info/gems/httpauth/0.1/HTTPAuth/Basic#pack_authorization-class_method
- https://dev.to/danroe/comment/1p98g
- https://mixedanalytics.com/tools/basic-authentication-generator/#what