### PR TITLE
134 show attachments

### DIFF
--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -64,7 +64,7 @@ const Request = () => {
   }
 
   // TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
-  // const handleSendingMessages = ({ message, files }) => {
+  // const handleSendingMessagesOrFiles = ({ message, files }) => {
   //   postMessageOrFile({
   //     id,
   //     message,
@@ -79,9 +79,9 @@ const Request = () => {
       <StatusBar statusArray={STATUS_ARRAY} apiRequestStatus={request.status.text} addClass='mt-4' />
       <div className='row mb-4'>
         <div className='col-sm-4 col-md-3 mt-2 mt-sm-4 order-1 order-sm-0'>
-          {/* TODO(@summercook): add back in the handleSendingMessages={handleSendingMessages} prop to ActionsGroup once the direction of
+          {/* TODO(@summercook): add back in the handleSendingMessagesOrFiles={handleSendingMessagesOrFiles} prop to ActionsGroup once the direction of
           https://github.com/scientist-softserv/webstore/issues/156 has been decided */}
-          <ActionsGroup files={files}/>
+          <ActionsGroup initialFiles={files}/>
           <div className='mt-3'>
             <RequestStats
               billingInfo={{ ...request.billingAddress }}

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -15,8 +15,8 @@ import {
 } from '@scientist-softserv/webstore-component-library'
 import {
   configureErrors,
-  postMessageOrAttachment,
-  useAllMessages,
+  postMessageOrFile,
+  useMessagesAndFiles,
   useAllSOWs,
   useOneRequest,
   STATUS_ARRAY,
@@ -28,11 +28,11 @@ const Request = () => {
   const { id } = router.query
   const { request, isLoadingRequest, isRequestError } = useOneRequest(id, session?.accessToken)
   const { allSOWs, isLoadingSOWs, isSOWError } = useAllSOWs(id, request?.identifier, session?.accessToken)
-  const { messages, isLoadingMessages, isMessagesError, mutate, data } = useAllMessages(id, session?.accessToken)
+  const { messages, isLoadingMessagesAndFiles, isMessagesAndFilesError, mutate, data } = useMessagesAndFiles(id, session?.accessToken)
   const documents = (allSOWs) ? [...allSOWs] : []
 
-  const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingMessages
-  const isError = isRequestError || isSOWError || isMessagesError
+  const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingMessagesAndFiles
+  const isError = isRequestError || isSOWError || isMessagesAndFilesError
 
   if (isLoading) return <Loading wrapperClass='item-page mt-5' />
 
@@ -65,7 +65,7 @@ const Request = () => {
 
   // TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
   // const handleSendingMessages = ({ message, files }) => {
-  //   postMessageOrAttachment({
+  //   postMessageOrFile({
   //     id,
   //     message,
   //     files,
@@ -79,9 +79,9 @@ const Request = () => {
       <StatusBar statusArray={STATUS_ARRAY} apiRequestStatus={request.status.text} addClass='mt-4' />
       <div className='row mb-4'>
         <div className='col-sm-4 col-md-3 mt-2 mt-sm-4 order-1 order-sm-0'>
-          {/* // TODO(alishaevn): return the below once the direction of
+          {/* TODO(@summercook): add back in the handleSendingMessages={handleSendingMessages} prop to ActionsGroup once the direction of
           https://github.com/scientist-softserv/webstore/issues/156 has been decided */}
-          {/* <ActionsGroup handleSendingMessages={handleSendingMessages}/> */}
+          <ActionsGroup attachments={{}}/>
           <div className='mt-3'>
             <RequestStats
               billingInfo={{ ...request.billingAddress }}

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -15,7 +15,7 @@ import {
 } from '@scientist-softserv/webstore-component-library'
 import {
   configureErrors,
-  postMessageOrFile,
+  createMessageOrFile,
   useMessagesAndFiles,
   useAllSOWs,
   useOneRequest,
@@ -72,7 +72,7 @@ const Request = () => {
   // TODO(summer-cook) need to use the quoted ware id here instead of the quote group id.
   // can be found at https://{{base_path}}/quote_groups/{{quote_group_id}}/quoted_wares.json
   // const handleSendingMessagesOrFiles = ({ message, files }) => {
-  //   postMessageOrFile({
+  //   createMessageOrFile({
   //     id,
   //     message,
   //     files,

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -28,7 +28,7 @@ const Request = () => {
   const { id } = router.query
   const { request, isLoadingRequest, isRequestError } = useOneRequest(id, session?.accessToken)
   const { allSOWs, isLoadingSOWs, isSOWError } = useAllSOWs(id, request?.identifier, session?.accessToken)
-  const { messages, isLoadingMessagesAndFiles, isMessagesAndFilesError, mutate, data } = useMessagesAndFiles(id, session?.accessToken)
+  const { messages, files, isLoadingMessagesAndFiles, isMessagesAndFilesError, mutate, data } = useMessagesAndFiles(id, session?.accessToken)
   const documents = (allSOWs) ? [...allSOWs] : []
 
   const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingMessagesAndFiles
@@ -81,7 +81,7 @@ const Request = () => {
         <div className='col-sm-4 col-md-3 mt-2 mt-sm-4 order-1 order-sm-0'>
           {/* TODO(@summercook): add back in the handleSendingMessages={handleSendingMessages} prop to ActionsGroup once the direction of
           https://github.com/scientist-softserv/webstore/issues/156 has been decided */}
-          <ActionsGroup attachments={{}}/>
+          <ActionsGroup files={files}/>
           <div className='mt-3'>
             <RequestStats
               billingInfo={{ ...request.billingAddress }}

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -52,7 +52,7 @@ const Request = () => {
   if (isError) {
     return (
       <Notice
-        alert={configureErrors([isRequestError, isSOWError, isMessagesError])}
+        alert={configureErrors([isRequestError, isSOWError, isMessagesAndFilesError])}
         dismissible={false}
         withBackButton={true}
         buttonProps={{

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -104,7 +104,7 @@ const Request = () => {
           <CollapsibleSection header='Additional Information' description={request.htmlDescription} />
           <Title addClass='mt-4' title='Documents' size='small' />
           {documents.length ? documents.map((document, index) => (
-            <Document key={index} document={document} addClass='mt-3' />
+            <Document key={`${request.id}-${index}`} document={document} addClass='mt-3' />
           )) : (
             <TextBox
               alignment='left'

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -25,10 +25,16 @@ import {
 const Request = () => {
   const router = useRouter()
   const { data: session } = useSession()
+  // queries the router to get the quote group (request) id
   const { id } = router.query
   const { request, isLoadingRequest, isRequestError } = useOneRequest(id, session?.accessToken)
   const { allSOWs, isLoadingSOWs, isSOWError } = useAllSOWs(id, request?.identifier, session?.accessToken)
-  const { messages, files, isLoadingMessagesAndFiles, isMessagesAndFilesError, mutate, data } = useMessagesAndFiles(id, session?.accessToken)
+  const { messages, 
+    files, 
+    isLoadingMessagesAndFiles, 
+    isMessagesAndFilesError, 
+    mutate, 
+    data } = useMessagesAndFiles(id, session?.accessToken)
   const documents = (allSOWs) ? [...allSOWs] : []
 
   const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingMessagesAndFiles
@@ -63,7 +69,8 @@ const Request = () => {
     )
   }
 
-  // TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
+  // TODO(summer-cook) need to use the quoted ware id here instead of the quote group id.
+  // can be found at https://{{base_path}}/quote_groups/{{quote_group_id}}/quoted_wares.json
   // const handleSendingMessagesOrFiles = ({ message, files }) => {
   //   postMessageOrFile({
   //     id,
@@ -79,8 +86,9 @@ const Request = () => {
       <StatusBar statusArray={STATUS_ARRAY} apiRequestStatus={request.status.text} addClass='mt-4' />
       <div className='row mb-4'>
         <div className='col-sm-4 col-md-3 mt-2 mt-sm-4 order-1 order-sm-0'>
-          {/* TODO(@summercook): add back in the handleSendingMessagesOrFiles={handleSendingMessagesOrFiles} prop to ActionsGroup once the direction of
-          https://github.com/scientist-softserv/webstore/issues/156 has been decided */}
+          {/* TODO(@summercook): 
+          - add back in the handleSendingMessagesOrFiles={handleSendingMessagesOrFiles} prop
+            to ActionsGroup once posting messages/attachments has been refactored. */}
           <ActionsGroup initialFiles={files}/>
           <div className='mt-3'>
             <RequestStats

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -25,7 +25,7 @@ import {
 const Request = () => {
   const router = useRouter()
   const { data: session } = useSession()
-  // queries the router to get the quote group (request) id
+  // parses the query string to get the quote group (request) id
   const { id } = router.query
   const { request, isLoadingRequest, isRequestError } = useOneRequest(id, session?.accessToken)
   const { allSOWs, isLoadingSOWs, isSOWError } = useAllSOWs(id, request?.identifier, session?.accessToken)

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -103,8 +103,8 @@ const Request = () => {
           <Title title={request.title} />
           <CollapsibleSection header='Additional Information' description={request.htmlDescription} />
           <Title addClass='mt-4' title='Documents' size='small' />
-          {documents.length ? documents.map(document => (
-            <Document key={request.id} document={document} addClass='mt-3' />
+          {documents.length ? documents.map((document, index) => (
+            <Document key={index} document={document} addClass='mt-3' />
           )) : (
             <TextBox
               alignment='left'

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -156,12 +156,15 @@ export const  configureFiles = (data) => {
   // modify the object for each file
   notesWithFiles.map(note => {
     let singleFileArray = note.attachments.map(file => ({
-      ...file,
-      uploadedBy: note.created_by,
-      status: note.status,
-      createdAt: normalizeDate(file.created_at),
       contentLength: formatBytes(file.content_length),
-      href: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/secure_attachments/${file.uuid}`
+      contentType: note.content_type,
+      createdAt: normalizeDate(file.created_at),
+      download: note.download,
+      fileName: note.filename,
+      href: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/secure_attachments/${file.uuid}`,
+      status: note.status,
+      uploadedBy: note.created_by,
+      uuid: note.uuid
     }))
     fileArrays.push(singleFileArray)
   })

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -155,6 +155,7 @@ export const  configureFiles = (data) => {
   const allFiles = notesWithFiles.map(note => {
     return note.attachments.map(file => ({
       ...file,
+      status: note.status,
       createdAt: normalizeDate(file.created_at),
       contentLength: formatBytes(file.content_length),
       href: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/secure_attachments/${file.uuid}`

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -157,14 +157,14 @@ export const  configureFiles = (data) => {
   notesWithFiles.map(note => {
     let singleFileArray = note.attachments.map(file => ({
       contentLength: formatBytes(file.content_length),
-      contentType: note.content_type,
+      contentType: file.content_type,
       createdAt: normalizeDate(file.created_at),
-      download: note.download,
-      fileName: note.filename,
+      download: file.download,
+      fileName: file.filename,
       href: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/secure_attachments/${file.uuid}`,
       status: note.status,
       uploadedBy: note.created_by,
-      uuid: note.uuid
+      uuid: file.uuid
     }))
     fileArrays.push(singleFileArray)
   })

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -148,6 +148,25 @@ export const configureMessages = (data) => {
   }))
 }
 
+export const  configureFiles = (data) => {
+  // NOTE(alishaevn): doing some basic filtering here until we come to a resolution on
+  // https://github.com/assaydepot/scientist_api_v2/issues/167
+  const filteredMessages = data.filter(d => d.user_ref && d.body)
+
+  return filteredMessages.map(note => ({
+    avatar: note.user_ref.image,
+    body: note.body,
+    id: note.id,
+    name: `${note.user_ref.first_name} ${note.user_ref.last_name}`,
+    timeSince: timeSince(Date.parse(note.created_at)),
+    attachments: note.attachments.map((attachment) => ({
+      ...attachment,
+      contentLength: formatBytes(attachment.content_length),
+      href: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/secure_attachments/${attachment.uuid}`
+    })) || [],
+  }))
+}
+
 export const configureDocuments = (documents, requestIdentifier) => {
   return documents?.map(document => ({
     identifier: document.identifier,

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -151,20 +151,16 @@ export const configureMessages = (data) => {
 export const  configureFiles = (data) => {
   // NOTE(alishaevn): doing some basic filtering here until we come to a resolution on
   // https://github.com/assaydepot/scientist_api_v2/issues/167
-  const filteredMessages = data.filter(d => d.user_ref && d.body)
-
-  return filteredMessages.map(note => ({
-    avatar: note.user_ref.image,
-    body: note.body,
-    id: note.id,
-    name: `${note.user_ref.first_name} ${note.user_ref.last_name}`,
-    timeSince: timeSince(Date.parse(note.created_at)),
-    attachments: note.attachments.map((attachment) => ({
-      ...attachment,
-      contentLength: formatBytes(attachment.content_length),
-      href: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/secure_attachments/${attachment.uuid}`
-    })) || [],
-  }))
+  const notesWithFiles = data.filter(d => d.attachments?.length !== 0)
+  const allFiles = notesWithFiles.map(note => {
+    return note.attachments.map(file => ({
+      ...file,
+      createdAt: normalizeDate(file.created_at),
+      contentLength: formatBytes(file.content_length),
+      href: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/secure_attachments/${file.uuid}`
+    }))
+  })
+  return allFiles
 }
 
 export const configureDocuments = (documents, requestIdentifier) => {

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -151,16 +151,24 @@ export const configureMessages = (data) => {
 export const  configureFiles = (data) => {
   // NOTE(alishaevn): doing some basic filtering here until we come to a resolution on
   // https://github.com/assaydepot/scientist_api_v2/issues/167
+  // filter out the notes that do not have attachments 
   const notesWithFiles = data.filter(d => d.attachments?.length !== 0)
-  const allFiles = notesWithFiles.map(note => {
-    return note.attachments.map(file => ({
+  let fileArrays = []
+
+  // modify the object for each file
+  notesWithFiles.map(note => {
+    let singleFileArray = note.attachments.map(file => ({
       ...file,
       status: note.status,
       createdAt: normalizeDate(file.created_at),
       contentLength: formatBytes(file.content_length),
       href: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/secure_attachments/${file.uuid}`
     }))
+    fileArrays.push(singleFileArray)
   })
+
+  // flatten the array of file arrays so we have a single array of only files
+  const allFiles = [].concat(...fileArrays)
   return allFiles
 }
 

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -159,6 +159,7 @@ export const  configureFiles = (data) => {
   notesWithFiles.map(note => {
     let singleFileArray = note.attachments.map(file => ({
       ...file,
+      uploadedBy: note.created_by,
       status: note.status,
       createdAt: normalizeDate(file.created_at),
       contentLength: formatBytes(file.content_length),

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -149,8 +149,6 @@ export const configureMessages = (data) => {
 }
 
 export const  configureFiles = (data) => {
-  // NOTE(alishaevn): doing some basic filtering here until we come to a resolution on
-  // https://github.com/assaydepot/scientist_api_v2/issues/167
   // filter out the notes that do not have attachments 
   const notesWithFiles = data.filter(d => d.attachments?.length !== 0)
   let fileArrays = []

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import {
+  configureFiles,
   configureDocuments,
   configureMessages,
   configureRequests,
@@ -51,22 +52,27 @@ export const useAllSOWs = (id, requestIdentifier, accessToken) => {
   }
 }
 
-export const useAllMessages = (id, accessToken) => {
+export const useMessagesAndFiles = (id, accessToken) => {
   const { data, error, mutate } = useSWR(id ? [`/quote_groups/${id}/notes.json`, accessToken] : null)
   let messages
-  if (data) messages = configureMessages(data.notes)
+  let files
+  if (data) {
+    messages = configureMessages(data.notes)
+    files =  configureFiles(data.notes)
+  }
 
   return {
     data,
     messages,
+    files,
     mutate,
-    isLoadingMessages: !error && !data,
-    isMessageError: error,
+    isLoadingMessagesAndFiles: !error && !data,
+    isMessagesAndFilesError: error,
   }
 }
 
 // TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
-export const postMessageOrAttachment = ({ id, message, files, accessToken }) => {
+export const postMessageOrFile = ({ id, message, files, accessToken }) => {
   /* eslint-disable camelcase */
 
   // in the scientist marketplace, both user messages sent on a request's page and
@@ -133,7 +139,7 @@ export const createRequest = async ({ data, wareID, accessToken }) => {
   }
 
   const response = await posting(`/wares/${wareID}/quote_groups.json`, { pg_quote_group }, accessToken)
-  postMessageOrAttachment({ id: response.requestID, files: data.attachments })
+  postMessageOrFile({ id: response.requestID, files: data.attachments })
 
   return response
   /* eslint-enable camelcase */

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -72,7 +72,7 @@ export const useMessagesAndFiles = (id, accessToken) => {
 }
 
 // TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
-export const postMessageOrFile = ({ id, message, files, accessToken }) => {
+export const createMessageOrFile = ({ id, message, files, accessToken }) => {
   /* eslint-disable camelcase */
 
   // in the scientist marketplace, both user messages sent on a request's page and
@@ -139,7 +139,7 @@ export const createRequest = async ({ data, wareID, accessToken }) => {
   }
 
   const response = await posting(`/wares/${wareID}/quote_groups.json`, { pg_quote_group }, accessToken)
-  postMessageOrFile({ id: response.requestID, files: data.attachments })
+  createMessageOrFile({ id: response.requestID, files: data.attachments })
 
   return response
   /* eslint-enable camelcase */


### PR DESCRIPTION
## story
- updates variables to semantically include both messages & files, since these both are accounted for by the notes endpoint
- creates a configure files method so that the attachments are returned as a single array vs being nested to make the viewfiles component simpler.
- returns both files and messages as variables to be used in the `pages/requests/[id].js` page & passed to respective request page components

## related
component library pr: https://github.com/scientist-softserv/webstore-component-library/pull/150
ticket: https://github.com/scientist-softserv/webstore-component-library/issues/134

## notes
- should not be merged until related component library pr is merged.