### PR TITLE
184 make only the button clickable

### DIFF
--- a/pages/requests/index.js
+++ b/pages/requests/index.js
@@ -55,15 +55,16 @@ const Requests = () => {
 
   return (
     <div className='container'>
-      <LinkedButton
-        buttonProps={{
-          backgroundColor: dark,
-          label: 'Initiate a New Request',
-          size: 'large',
-        }}
-        path={{ pathname: `/requests/new/make-a-request`, query: { id: defaultWareID } }}
-        addClass='text-end d-block mt-4 mb-2'
-      />
+      <div className='text-end d-block mt-4 mb-2'>
+        <LinkedButton
+          buttonProps={{
+            backgroundColor: dark,
+            label: 'Initiate a New Request',
+            size: 'large',
+          }}
+          path={{ pathname: `/requests/new/make-a-request`, query: { id: defaultWareID } }}
+        />
+      </div>
       <RequestList requests={requests} />
     </div>
   )


### PR DESCRIPTION
## summary
since the outer wrapper of the LinkedButton component is an a-tag, it should not be full width or else the link will span the full width as opposed to just being on the button. this pr fixes that

## related
Closes #184 

Closes 
## video
https://share.getcloudapp.com/yAuAEjvB