### PR TITLE
Add a provider_ids array to the create request params

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -75,7 +75,7 @@ export const useMessagesAndFiles = (id, accessToken) => {
 }
 
 export const useInitializeRequest = (id, accessToken) => {
-  const { data, error } = useSWR(id ? [`/wares/${id}/quote_groups.json`, accessToken] : null)
+  const { data, error } = useSWR(id ? [`/wares/${id}/quote_groups/new.json`, accessToken] : null)
   let dynamicForm = { name: data?.name }
   let dynamicFormInfo = data?.dynamic_forms[0]
 
@@ -147,6 +147,7 @@ export const createRequest = async ({ data, wareID, accessToken }) => {
   const pg_quote_group = {
     ...formData,
     name: data.name,
+    provider_ids: [process.env.NEXT_PUBLIC_PROVIDER_ID],
     suppliers_identified: 'Yes',
     description: requestDescription,
     proposed_deadline_str: data.proposedDeadline,


### PR DESCRIPTION
# summary
the uuid is needed to send messages/attachments, and this lives on the `quoted_ware_refs`. Webstore users will need the option to send an attachment during creation of the request, but quoted_ware_refs are not being added until a proposal is created. This can be added sooner by passing the provider_id during request creation.

# related
Closes https://github.com/scientist-softserv/webstore/issues/208

# screenshots
newly created request:
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/73361970/219437662-bef351dc-8bd9-4651-9bc4-97a3d74d9a0d.png">

in postman:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/73361970/219437581-e8c91bca-355d-4e2b-b82a-ba65bcafb14c.png">
