### PR TITLE
use new endpoint to filter messages

### DIFF
--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -16,6 +16,8 @@ import {
 import {
   configureErrors,
   createMessageOrFile,
+  useMessages,
+  useFiles,
   useMessagesAndFiles,
   useAllSOWs,
   useOneRequest,
@@ -29,18 +31,12 @@ const Request = () => {
   const { id } = router.query
   const { request, isLoadingRequest, isRequestError } = useOneRequest(id, session?.accessToken)
   const { allSOWs, isLoadingSOWs, isSOWError } = useAllSOWs(id, request?.identifier, session?.accessToken)
-  const {
-    messages, 
-    files, 
-    isLoadingMessagesAndFiles, 
-    isMessagesAndFilesError, 
-    mutate, 
-    data,
-  } = useMessagesAndFiles(id, session?.accessToken)
+  const { messages, isLoadingMessages, isMessagesError, mutate, data } = useMessages(request?.uuid, session?.accessToken)
+  const { files, isLoadingFiles, isFilesError } = useFiles(id, session?.accessToken)
   const documents = (allSOWs) ? [...allSOWs] : []
 
-  const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingMessagesAndFiles
-  const isError = isRequestError || isSOWError || isMessagesAndFilesError
+  const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingFiles || isLoadingMessages
+  const isError = isRequestError || isSOWError || isFilesError|| isMessagesError
 
   if (isLoading) return <Loading wrapperClass='item-page mt-5' />
 
@@ -60,7 +56,7 @@ const Request = () => {
   if (isError) {
     return (
       <Notice
-        alert={configureErrors([isRequestError, isSOWError, isMessagesAndFilesError])}
+        alert={configureErrors([isRequestError, isSOWError, isMessagesError, isFilesError])}
         dismissible={false}
         withBackButton={true}
         buttonProps={{

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -56,6 +56,7 @@ export const configureRequests = ({ data, path }) => {
       },
       title: `${request.identifier}: ${request.name}`,
       updatedAt: normalizeDate(request.updated_at),
+      uuid: request.uuid,
     }
   })
 }

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -55,24 +55,36 @@ export const useAllSOWs = (id, requestIdentifier, accessToken) => {
   }
 }
 
-export const useMessagesAndFiles = (id, accessToken) => {
-  const { data, error, mutate } = useSWR(id ? [`/quote_groups/${id}/notes.json`, accessToken] : null)
+export const useMessages = (requestUuid, accessToken) => {
+  const { data, error, mutate } = useSWR(requestUuid ? [`/quote_groups/${requestUuid}/messages.json`, accessToken] : null)
   let messages
-  let files
   if (data) {
-    messages = configureMessages(data.notes)
-    files =  configureFiles(data.notes)
+    messages = configureMessages(data.messages)
   }
 
   return {
     data,
     messages,
-    files,
     mutate,
-    isLoadingMessagesAndFiles: !error && !data,
-    isMessagesAndFilesError: error,
+    isLoadingMessages: !error && !data,
+    isMessagesError: error,
   }
 }
+
+export const useFiles = (id, accessToken) => {
+  const { data, error, mutate } = useSWR(id ? [`/quote_groups/${id}/notes.json`, accessToken] : null)
+  let files
+  if (data) {
+    files =  configureFiles(data.notes)
+  }
+
+  return {
+    files,
+    isLoadingFiles: !error && !data,
+    isFilesError: error,
+  }
+}
+
 
 export const useInitializeRequest = (id, accessToken) => {
   const { data, error } = useSWR(id ? [`/wares/${id}/quote_groups/new.json`, accessToken] : null)

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -72,7 +72,7 @@ export const useMessages = (requestUuid, accessToken) => {
 }
 
 export const useFiles = (id, accessToken) => {
-  const { data, error, mutate } = useSWR(id ? [`/quote_groups/${id}/notes.json`, accessToken] : null)
+  const { data, error } = useSWR(id ? [`/quote_groups/${id}/notes.json`, accessToken] : null)
   let files
   if (data) {
     files =  configureFiles(data.notes)


### PR DESCRIPTION
# Story
uses the new messages endpoint to filter the messages on the request page `/quote_groups/${requestUuid}/messages.json`

Closes #110 

# Expected Behavior Before Changes
all messages would show on the request page

# Expected Behavior After Changes
the internal messages will be filtered out on the request page (for instance: "username has initiated the request")

# Screenshots / Video

<details>
<summary>Request with no messages in webstore- internal messages no longer appear automatically</summary>
<img width="500" alt="image" src="https://user-images.githubusercontent.com/73361970/219475067-87e0c499-d04d-4271-9f72-3e066a5714f6.png">

</details>

<details>
<summary>Request with messages in webstore</summary>
<img width="500" alt="image" src="https://user-images.githubusercontent.com/73361970/219489938-a99e76ce-3041-404f-a85f-2a97cb605673.png">


</details>