### PR TITLE
156 refactor sending messages

### DIFF
--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -18,7 +18,6 @@ import {
   createMessageOrFile,
   useMessages,
   useFiles,
-  useMessagesAndFiles,
   useAllSOWs,
   useOneRequest,
   STATUS_ARRAY,
@@ -67,27 +66,23 @@ const Request = () => {
     )
   }
 
-  // TODO(summer-cook) need to use the quoted ware id here instead of the quote group id.
-  // can be found at https://{{base_path}}/quote_groups/{{quote_group_id}}/quoted_wares.json
-  // const handleSendingMessagesOrFiles = ({ message, files }) => {
-  //   createMessageOrFile({
-  //     id,
-  //     message,
-  //     files,
-  //     accessToken: session?.accessToken,
-  //   })
-  //   mutate({ ...data, ...messages })
-  // }
+  const handleSendingMessagesOrFiles = ({ message, files }) => {
+    createMessageOrFile({
+      id,
+      message,
+      files,
+      accessToken: session?.accessToken,
+      quotedWareId: request.quotedWareId,
+    })
+    mutate({ ...data, ...messages })
+  }
 
   return (
     <div className='container'>
       <StatusBar statusArray={STATUS_ARRAY} apiRequestStatus={request.status.text} addClass='mt-4' />
       <div className='row mb-4'>
         <div className='col-sm-4 col-md-3 mt-2 mt-sm-4 order-1 order-sm-0'>
-          {/* TODO(@summercook): 
-          - add back in the handleSendingMessagesOrFiles={handleSendingMessagesOrFiles} prop
-            to ActionsGroup once posting messages/attachments has been refactored. */}
-          <ActionsGroup initialFiles={files}/>
+          <ActionsGroup initialFiles={files} handleSendingMessagesOrFiles={handleSendingMessagesOrFiles}/>
           <div className='mt-3'>
             <RequestStats
               billingInfo={{ ...request.billingAddress }}

--- a/pages/requests/[id].js
+++ b/pages/requests/[id].js
@@ -72,7 +72,7 @@ const Request = () => {
       message,
       files,
       accessToken: session?.accessToken,
-      quotedWareId: request.quotedWareId,
+      quotedWareID: request.quotedWareID,
     })
     mutate({ ...data, ...messages })
   }

--- a/utils/api/base.js
+++ b/utils/api/base.js
@@ -20,7 +20,7 @@ export const posting = async (url, data, token) => {
     const response = await api.post(url, data, { headers: defaultHeaders(token) })
     let quotedWareID = response.data.quoted_ware_refs?.[0].id
     let requestID = response.data.id
-    if (requestID && quotedWareID) {
+    if (requestID) {
       return {
         success: true,
         error: false,

--- a/utils/api/base.js
+++ b/utils/api/base.js
@@ -18,12 +18,12 @@ export const fetcher = (url, token) => {
 export const posting = async (url, data, token) => {
   try {
     const response = await api.post(url, data, { headers: defaultHeaders(token) })
-
-    if (response.data.id) {
+    if (response.data.id && response.quoted_ware_refs?.[0].id) {
       return {
         success: true,
         error: false,
         requestID: response.data.id,
+        quotedWareID: response.quoted_ware_refs?.[0].id
       }
     }
   } catch (error) {

--- a/utils/api/base.js
+++ b/utils/api/base.js
@@ -18,12 +18,14 @@ export const fetcher = (url, token) => {
 export const posting = async (url, data, token) => {
   try {
     const response = await api.post(url, data, { headers: defaultHeaders(token) })
-    if (response.data.id && response.quoted_ware_refs?.[0].id) {
+    let quotedWareID = response.data.quoted_ware_refs?.[0].id
+    let requestID = response.data.id
+    if (requestID && quotedWareID) {
       return {
         success: true,
         error: false,
-        requestID: response.data.id,
-        quotedWareID: response.quoted_ware_refs?.[0].id
+        requestID,
+        quotedWareID
       }
     }
   } catch (error) {

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -57,7 +57,7 @@ export const configureRequests = ({ data, path }) => {
       title: `${request.identifier}: ${request.name}`,
       updatedAt: normalizeDate(request.updated_at),
       uuid: request.uuid,
-      quotedWareId: request.quoted_ware_refs[0].id
+      quotedWareId: request.quoted_ware_refs?.[0].id
     }
   })
 }

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -29,7 +29,7 @@ export const configureRequests = ({ data, path }) => {
     ? data.sort((a, b) => b.updated_at.localeCompare(a.updated_at))
     : [data]
 
-  return sortedRequests?.map(request => {
+    return sortedRequests?.map(request => {
     const status = configureStatus(request.status)
     return {
       billingAddress: {
@@ -57,6 +57,7 @@ export const configureRequests = ({ data, path }) => {
       title: `${request.identifier}: ${request.name}`,
       updatedAt: normalizeDate(request.updated_at),
       uuid: request.uuid,
+      quotedWareId: request.quoted_ware_refs[0].id
     }
   })
 }

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -29,7 +29,7 @@ export const configureRequests = ({ data, path }) => {
     ? data.sort((a, b) => b.updated_at.localeCompare(a.updated_at))
     : [data]
 
-    return sortedRequests?.map(request => {
+  return sortedRequests?.map(request => {
     const status = configureStatus(request.status)
     return {
       billingAddress: {

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -57,7 +57,7 @@ export const configureRequests = ({ data, path }) => {
       title: `${request.identifier}: ${request.name}`,
       updatedAt: normalizeDate(request.updated_at),
       uuid: request.uuid,
-      quotedWareId: request.quoted_ware_refs?.[0].id
+      quotedWareID: request.quoted_ware_refs?.[0].id
     }
   })
 }

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -121,7 +121,7 @@ export const useDefaultWare = (accessToken) => {
 }
 
 /** POST METHODS */
-export const createMessageOrFile = ({ id, quotedWareId, message, files, accessToken }) => {
+export const createMessageOrFile = ({ id, quotedWareID, message, files, accessToken }) => {
   /* eslint-disable camelcase */
 
   // in the scientist marketplace, both user messages sent on a request's page and
@@ -132,7 +132,7 @@ export const createMessageOrFile = ({ id, quotedWareId, message, files, accessTo
     title: message ? null : 'New Attachment',
     status: message ? null : 'Other File',
     body: message || null,
-    quoted_ware_ids: [quotedWareId],
+    quoted_ware_ids: [quotedWareID],
     data_files: files,
   }
   /* eslint-enable camelcase */

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -122,7 +122,7 @@ export const useDefaultWare = (accessToken) => {
 
 /** POST METHODS */
 // TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
-export const createMessageOrFile = ({ id, message, files, accessToken }) => {
+export const createMessageOrFile = ({ id, quotedWareId, message, files, accessToken }) => {
   /* eslint-disable camelcase */
 
   // in the scientist marketplace, both user messages sent on a request's page and
@@ -133,12 +133,12 @@ export const createMessageOrFile = ({ id, message, files, accessToken }) => {
     title: message ? null : 'New Attachment',
     status: message ? null : 'Other File',
     body: message || null,
-    quoted_ware_ids: [id],
+    quoted_ware_ids: [quotedWareId],
     data_files: files,
   }
   /* eslint-enable camelcase */
 
-  // posting(`/quote_groups/${id}/notes.json`, note, accessToken)
+  posting(`/quote_groups/${id}/notes.json`, note, accessToken)
 }
 
 export const createRequest = async ({ data, wareID, accessToken }) => {

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -121,7 +121,6 @@ export const useDefaultWare = (accessToken) => {
 }
 
 /** POST METHODS */
-// TODO(alishaevn): refactor the below once the direction of https://github.com/scientist-softserv/webstore/issues/156 has been decided
 export const createMessageOrFile = ({ id, quotedWareId, message, files, accessToken }) => {
   /* eslint-disable camelcase */
 
@@ -190,7 +189,8 @@ export const createRequest = async ({ data, wareID, accessToken }) => {
   }
 
   const response = await posting(`/wares/${wareID}/quote_groups.json`, { pg_quote_group }, accessToken)
-  createMessageOrFile({ id: response.requestID, files: data.attachments })
+  console.log({response})
+  //createMessageOrFile({ id: response.requestID, files: data.attachments })
 
   return response
   /* eslint-enable camelcase */

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -189,8 +189,7 @@ export const createRequest = async ({ data, wareID, accessToken }) => {
   }
 
   const response = await posting(`/wares/${wareID}/quote_groups.json`, { pg_quote_group }, accessToken)
-  console.log({response})
-  //createMessageOrFile({ id: response.requestID, files: data.attachments })
+  createMessageOrFile({ id: response.requestID, files: data.attachments, quotedWareID: response.quotedWareID })
 
   return response
   /* eslint-enable camelcase */


### PR DESCRIPTION
# Story
brings back the ability to send messages, and adds the quotedWareID to the request so it can be passed in the post message request as well as in the posting method since it needed to be used when adding initial attachments

Ref #156 

# Expected Behavior Before Changes
messages could not be sent from the webstore, and were sent with the incorrect param of quote_group_id vs the ID of the quoted_ware. 

# Expected Behavior After Changes
- [ ] messages can be sent from the webstore to the correct quote_group/quoted_ware combo
- [ ] attachments can be sent when creating a request with the correct quote_group/quoted_ware combo
