### PR TITLE
210-search-on-browse-tests

### DIFF
--- a/cypress/e2e/browsing.cy.js
+++ b/cypress/e2e/browsing.cy.js
@@ -27,7 +27,41 @@ describe('Browsing', () => {
     cy.get('button.search-button').click()
 
     // The new url should include "/browse"
-    cy.url().should('include', '/browse?=next')
+    cy.url().should('include', '/browse?q=next')
+
+    // The search bar on the browse page should have the text that was searched for
+    cy.get('input.search-bar').should('have.value', 'next')
+  })
+
+  it('completes a search from the "/browse" with a blank query', () => {
+    // Start from the browse page
+    cy.visit('/browse')
+
+    // Find the search button and perform an empty search, which should lead to the browse page
+    cy.get('button.search-button').click()
+
+    // The new url should include "/browse"
+    cy.url().should('include', '/browse')
+
+    // The new url should not contain a query
+    cy.url().should('not.include', '?')
+
+    // The search bar on the browse page should remain blank
+    cy.get('input.search-bar').should('have.value', '')
+  })
+
+  it('completes a search from "/browse" with a query term', () => {
+    // Start from the browse page
+    cy.visit('/browse')
+
+    // type an example search into the searchbar
+    cy.get('input.search-bar').type('next')
+
+    // Press the search button
+    cy.get('button.search-button').click()
+
+    // The new url should include "/browse"
+    cy.url().should('include', '/browse?q=next')
 
     // The search bar on the browse page should have the text that was searched for
     cy.get('input.search-bar').should('have.value', 'next')


### PR DESCRIPTION
add 2 tests for browsing on the browse page. edit 1 test to include 'q' in the test's url

# Story

Refs #210

I added 2 tests in `cypress/e2e/browsing.cy.js`:
1. a user conducting a blank search on /browse
2. a user conducting a queried search on /browse

I also edited a pre-existing test on line 30 of `cypress/e2e/browsing.cy.js`:
- this test did not include the `q` in the URL for `cy.url().should('include', '/browse?q=next')`. On my local test runs, omitting the `q` from `'/browse?q=next'` led to a failure.

# Expected Behavior Before Changes

1. /browse did not have tests for searching on `browse`
2. Line 30 test failed

# Expected Behavior After Changes

1. /browse has 2 tests for searching on `browse`
2. Line 30 test passes

# Screenshots / Video

<details>
<summary>Line 30 test: before and after I added 'q' to line 30's test's URL</summary>

![webstore 2023-02-17 at 9 30 42 AM](https://user-images.githubusercontent.com/29311858/219729532-b04f3706-ab87-4b8b-96b2-e238199d789b.jpg)
![webstore 2023-02-17 at 9 29 38 AM](https://user-images.githubusercontent.com/29311858/219729569-5a315d55-9c1e-413b-83df-536172cbf88d.jpg)
</details>

# Notes

Please let me know if my change to line 30 is incorrect or unexpected lol