### PR TITLE
171 request uuid

### DIFF
--- a/pages/requests/[uuid].js
+++ b/pages/requests/[uuid].js
@@ -30,7 +30,7 @@ const Request = () => {
   const router = useRouter()
   const { data: session } = useSession()
   /**
-   * since this is a dynamically routed file, the router query will always consist of a "key: value" pair that's determined by the name of
+   * as a dynamically routed file, the router query will always consist of a "key: value" pair that's determined by the name of
    * the file (key) and path string (value). additional query properties may also exist if they were explicitly passed.
   */
   const { uuid } = router.query

--- a/pages/requests/[uuid].js
+++ b/pages/requests/[uuid].js
@@ -30,8 +30,8 @@ const Request = () => {
   const router = useRouter()
   const { data: session } = useSession()
   /**
-   * since this is a dynamically routed file, the router query will always consist of a "key: value" pair that's determined by the name of the file (key) and path string (value).
-   * additional query properties may also exist if they were explicitly passed.
+   * since this is a dynamically routed file, the router query will always consist of a "key: value" pair that's determined by the name of
+   * the file (key) and path string (value). additional query properties may also exist if they were explicitly passed.
   */
   const { uuid } = router.query
   const { request, isLoadingRequest, isRequestError } = useOneRequest(uuid, session?.accessToken)

--- a/pages/requests/[uuid].js
+++ b/pages/requests/[uuid].js
@@ -39,7 +39,6 @@ const Request = () => {
   const { messages, isLoadingMessages, isMessagesError, mutate, data } = useMessages(uuid, session?.accessToken)
   const { files, isLoadingFiles, isFilesError } = useFiles(uuid, session?.accessToken)
   const documents = (allSOWs) ? [...allSOWs] : []
-  console.log({ request })
 
   const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingFiles || isLoadingMessages
   const isError = isRequestError || isSOWError || isFilesError|| isMessagesError

--- a/pages/requests/[uuid].js
+++ b/pages/requests/[uuid].js
@@ -29,13 +29,17 @@ import {
 const Request = () => {
   const router = useRouter()
   const { data: session } = useSession()
-  // parses the query string to get the quote group (request) id
-  const { id } = router.query
-  const { request, isLoadingRequest, isRequestError } = useOneRequest(id, session?.accessToken)
-  const { allSOWs, isLoadingSOWs, isSOWError } = useAllSOWs(id, request?.identifier, session?.accessToken)
-  const { messages, isLoadingMessages, isMessagesError, mutate, data } = useMessages(request?.uuid, session?.accessToken)
-  const { files, isLoadingFiles, isFilesError } = useFiles(id, session?.accessToken)
+  /**
+   * since this is a dynamically routed file, the router query will always consist of a "key: value" pair that's determined by the name of the file (key) and path string (value).
+   * additional query properties may also exist if they were explicitly passed.
+  */
+  const { uuid } = router.query
+  const { request, isLoadingRequest, isRequestError } = useOneRequest(uuid, session?.accessToken)
+  const { allSOWs, isLoadingSOWs, isSOWError } = useAllSOWs(uuid, request?.identifier, session?.accessToken)
+  const { messages, isLoadingMessages, isMessagesError, mutate, data } = useMessages(uuid, session?.accessToken)
+  const { files, isLoadingFiles, isFilesError } = useFiles(uuid, session?.accessToken)
   const documents = (allSOWs) ? [...allSOWs] : []
+  console.log({ request })
 
   const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingFiles || isLoadingMessages
   const isError = isRequestError || isSOWError || isFilesError|| isMessagesError

--- a/pages/requests/[uuid].js
+++ b/pages/requests/[uuid].js
@@ -74,7 +74,7 @@ const Request = () => {
 
   const handleSendingMessagesOrFiles = ({ message, files }) => {
     createMessageOrFile({
-      id,
+      id: request.id,
       message,
       files,
       accessToken: session?.accessToken,

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -39,7 +39,10 @@ export const configureRequests = ({ data, path }) => {
       createdAt: normalizeDate(request.created_at),
       description: normalizeDescription(request.description),
       htmlDescription: normalizeHtmlDescription(request.description),
-      href: `${path}/${request.uuid}`,
+      href: {
+        pathname: `${path}/${request.uuid}`,
+        query: {},
+      },
       id: request.id,
       identifier: request.identifier,
       // TODO(alishaevn): pass the actual image here when it's available

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -39,7 +39,7 @@ export const configureRequests = ({ data, path }) => {
       createdAt: normalizeDate(request.created_at),
       description: normalizeDescription(request.description),
       htmlDescription: normalizeHtmlDescription(request.description),
-      href: `${path}/${request.id}`,
+      href: `${path}/${request.uuid}`,
       id: request.id,
       identifier: request.identifier,
       // TODO(alishaevn): pass the actual image here when it's available


### PR DESCRIPTION
# Story
when looking at a request show page in the webstore, the current url is "/requests/:id". this is because we do not have access to a uuid from the /quote_groups/mine.json endpoint. in order to align with the marketplace, we want the url to read "/requests/:uuid" instead.

# Expected Behavior Before Changes
- requests were referenced by their id on the show page

# Expected Behavior After Changes
- update the request href to use the uuid
- rename the [id] file to [uuid] since that is the value we are now basing the page on
- update the value of "href" in the "configureServices" function to pass an object with "pathname" and "query" values for consistency with other links in the app

# Screenshots / Video

https://user-images.githubusercontent.com/29032869/220400768-fb9295af-7aec-4237-afcd-bd36be5660d2.mp4