### PR TITLE
always define files

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -79,7 +79,7 @@ export const useFiles = (id, accessToken) => {
   }
 
   return {
-    files,
+    files: files || [],
     isLoadingFiles: !error && !data,
     isFilesError: error,
   }


### PR DESCRIPTION
# Expected Behavior Before Changes
- the actions group component would error when `files` was undefined
<details>
<summary>files error</summary>

![image](https://user-images.githubusercontent.com/29032869/220731495-94070329-58f7-4317-98ab-9367df6250e2.png)
</details>

# Expected Behavior After Changes
- make sure that `files` is at minimum an empty array on the request page. this accounts for the loading phase too. also makes sure the `filter` array method in actions group does not err out

# testing
- view a request show page
- click the "view files" action