### PR TITLE
143 refactor creating requests

### DIFF
--- a/pages/requests/[uuid].js
+++ b/pages/requests/[uuid].js
@@ -72,16 +72,19 @@ const Request = () => {
     )
   }
 
-  const handleSendingMessagesOrFiles = ({ message, files }) => {
-    createMessageOrFile({
+  const handleSendingMessagesOrFiles = async ({ message, files }) => {
+    const { data, error } = await createMessageOrFile({
       id: request.id,
       message,
       files,
       accessToken: session?.accessToken,
       quotedWareID: request.quotedWareID,
     })
-    mutateMessages({ ...messagesData, ...messages })
-    mutateFiles({ ...filesData, ...files })
+
+    if (data) {
+      mutateMessages({ ...messagesData, ...messages })
+      mutateFiles({ ...filesData, ...files })
+    }
   }
 
   return (

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -92,7 +92,7 @@ const NewRequest = () => {
     if (requestForm.billingSameAsShipping === true) Object.assign(requestForm.billing, requestForm.shipping)
 
     const { success, error, requestID } = await createRequest({
-      data: { name: dynamicForm.name, formData, ...requestForm },
+      dynamicFormData: { name: dynamicForm.name, formData, ...requestForm },
       wareID,
       accessToken: session?.accessToken,
     })

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -56,9 +56,8 @@ const NewRequest = () => {
   const [validated, setValidated] = useState(false)
   const [requestForm, setRequestForm] = useState(initialState)
   const [formData, setFormData] = useState(initialFormData)
-  const [requestSucceeded, setRequestSucceeded] = useState(false)
-  const [requestErred, setRequestErred] = useState(false)
-  const [requestID, setNewRequestID] = useState(undefined)
+  const [createRequestError, setCreateRequestError] = useState(undefined)
+  const [createdRequestUUID, setCreatedRequestUUID] = useState(undefined)
 
   /**
    * @param {object} event onChange event
@@ -91,27 +90,23 @@ const NewRequest = () => {
 
     if (requestForm.billingSameAsShipping === true) Object.assign(requestForm.billing, requestForm.shipping)
 
-    const { success, error, requestID } = await createRequest({
+    const { data, error } = await createRequest({
       dynamicFormData: { name: dynamicForm.name, formData, ...requestForm },
       wareID,
       accessToken: session?.accessToken,
     })
-    setRequestSucceeded(success)
-    setRequestErred(error)
-    setNewRequestID(requestID)
+    if (error) return setCreateRequestError(error)
+
+    setCreatedRequestUUID(data.uuid)
   }
 
   useEffect(() => {
-    if (requestSucceeded) {
+    if (createdRequestUUID) {
       router.push({
-        pathname: `/requests/${requestID}`
+        pathname: `/requests/${createdRequestUUID}`
       })
     }
-    if (requestErred) {
-      //TODO: set error alerts here
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [requestSucceeded, requestErred, requestID])
+  }, [createdRequestUUID])
 
   // TODO(alishaevn): use react bs placeholder component
   if (isLoadingInitialRequest || !wareID) return <Loading wrapperClass='item-page mt-5' />
@@ -139,6 +134,16 @@ const NewRequest = () => {
           onClick: () => router.back(),
           text: 'Click to return to the previous page.',
         }}
+      />
+    )
+  }
+
+  if (createRequestError) {
+    return (
+      <Notice
+        alert={configureErrors([createRequestError])}
+        dismissible={true}
+        withBackButton={false}
       />
     )
   }

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -106,6 +106,7 @@ const NewRequest = () => {
         pathname: `/requests/${createdRequestUUID}`
       })
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [createdRequestUUID])
 
   // TODO(alishaevn): use react bs placeholder component

--- a/utils/api/base.js
+++ b/utils/api/base.js
@@ -18,15 +18,10 @@ export const fetcher = (url, token) => {
 export const posting = async (url, data, token) => {
   try {
     const response = await api.post(url, data, { headers: defaultHeaders(token) })
-    let quotedWareID = response.data.quoted_ware_refs?.[0].id
-    let requestID = response.data.id
-    if (requestID) {
-      return {
-        success: true,
-        error: false,
-        requestID,
-        quotedWareID,
-      }
+
+    return {
+      data: response.data,
+      error: false,
     }
   } catch (error) {
     // TODO(alishaevn): handle the error when sentry is set up

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -69,7 +69,7 @@ export const configureRequests = ({ data, path }) => {
 export const configureErrors = (errors) => {
   const env = process.env.NODE_ENV
   const remainingErrors = errors
-    .filter(error => error)
+    .filter(error => Object.keys(error).length)
     .map(error => ({
       ...error,
       message: `${error.message} (${error.response?.data?.message})`,

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -161,7 +161,7 @@ export const configureMessages = (data) => {
 
 export const  configureFiles = (data) => {
   // filter out the notes that do not have attachments
-  const notesWithFiles = data.filter(d => d.attachments?.length !== 0)
+  const notesWithFiles = data.filter(d => d.attachments?.length)
   let fileArrays = []
 
   // modify the object for each file

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -190,9 +190,21 @@ export const createRequest = async ({ dynamicFormData, wareID, accessToken }) =>
     },
   }
 
-  const response = await posting(`/wares/${wareID}/quote_groups.json`, { pg_quote_group }, accessToken)
-  createMessageOrFile({ id: response.requestID, files: data.attachments, quotedWareID: response.quotedWareID })
+  let { data, error } = await posting(`/wares/${wareID}/quote_groups.json`, { pg_quote_group }, accessToken)
 
-  return response
+  if (data && dynamicFormData.attachments) {
+    const attachedFiles = await createMessageOrFile({
+      id: data.id,
+      files: dynamicFormData.attachments,
+      quotedWareID: data.quoted_ware_refs?.[0].id,
+    })
+
+    if (attachedFiles.error) {
+      // acknowledges that the request was created, but the file attachment failed
+      error = attachedFiles.error
+    }
+  }
+
+  return { data, error }
   /* eslint-enable camelcase */
 }

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -142,16 +142,16 @@ export const createMessageOrFile = ({ id, quotedWareID, message, files, accessTo
   posting(`/quote_groups/${id}/notes.json`, note, accessToken)
 }
 
-export const createRequest = async ({ data, wareID, accessToken }) => {
+export const createRequest = async ({ dynamicFormData, wareID, accessToken }) => {
   /* eslint-disable camelcase */
   // the api currently doesn't account for attachments
-  let requestDescription = data.description
-  let requestTimeline = data.timeline
-  let formData = data.formData
+  let requestDescription = dynamicFormData.description
+  let requestTimeline = dynamicFormData.timeline
+  let formData = dynamicFormData.formData
 
   // if the ware had a dynamic form, the description would come as part of the formData. otherwise, it comes from the local state
-  if (data.formData.description) {
-    const { description, timeline, ...remainingFormData } = data.formData
+  if (dynamicFormData.formData.description) {
+    const { description, timeline, ...remainingFormData } = dynamicFormData.formData
     formData = remainingFormData
     requestDescription = description
     requestTimeline = timeline
@@ -159,33 +159,33 @@ export const createRequest = async ({ data, wareID, accessToken }) => {
 
   const pg_quote_group = {
     ...formData,
-    name: data.name,
+    name: dynamicFormData.name,
     provider_ids: [process.env.NEXT_PUBLIC_PROVIDER_ID],
     suppliers_identified: 'Yes',
     description: requestDescription,
-    proposed_deadline_str: data.proposedDeadline,
-    no_proposed_deadline: data.proposedDeadline ? false : true,
+    proposed_deadline_str: dynamicFormData.proposedDeadline,
+    no_proposed_deadline: dynamicFormData.proposedDeadline ? false : true,
     timeline: requestTimeline,
     site: {
-      billing_same_as_shipping: data.billingSameAsShipping,
-      name: data.name,
+      billing_same_as_shipping: dynamicFormData.billingSameAsShipping,
+      name: dynamicFormData.name,
     },
     shipping_address_attributes: {
-      city: data.shipping.city,
-      country: data.shipping.country,
-      state: data.shipping.state,
-      street: data.shipping.street,
-      street2: data.shipping.street2,
-      zipcode: data.shipping.zipcode,
+      city: dynamicFormData.shipping.city,
+      country: dynamicFormData.shipping.country,
+      state: dynamicFormData.shipping.state,
+      street: dynamicFormData.shipping.street,
+      street2: dynamicFormData.shipping.street2,
+      zipcode: dynamicFormData.shipping.zipcode,
       organization_name: process.env.NEXT_PUBLIC_PROVIDER_NAME
     },
     billing_address_attributes: {
-      city: data.shipping.city,
-      country: data.shipping.country,
-      state: data.shipping.state,
-      street: data.shipping.street,
-      street2: data.shipping.street2,
-      zipcode: data.shipping.zipcode,
+      city: dynamicFormData.shipping.city,
+      country: dynamicFormData.shipping.country,
+      state: dynamicFormData.shipping.state,
+      street: dynamicFormData.shipping.street,
+      street2: dynamicFormData.shipping.street2,
+      zipcode: dynamicFormData.shipping.zipcode,
       organization_name: process.env.NEXT_PUBLIC_PROVIDER_NAME
     },
   }

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -139,7 +139,7 @@ export const createMessageOrFile = ({ id, quotedWareID, message, files, accessTo
   }
   /* eslint-enable camelcase */
 
-  posting(`/quote_groups/${id}/notes.json`, note, accessToken)
+  return posting(`/quote_groups/${id}/notes.json`, note, accessToken)
 }
 
 export const createRequest = async ({ dynamicFormData, wareID, accessToken }) => {


### PR DESCRIPTION
# Story
I noticed some areas for improvement that may also help our future selves while working on #226 

# Expected Behavior After Changes
- simplify `posting` so it is easier to use in other use cases in the future
- change the prop name passed into `createRequest` from "data" to "dynamicFormData" to remove conflicts after updating `posting`
- only try to attach files to a new request if there are any. also, account for attachment errors
- account for errors on the new request page and refactor for the new return values from `posting`
- an empty object is still truthy. check that the error has data in `configureErrors`
- checking that an array has length instead of if the length does not equal 0 (same thing, little less code)

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes