### PR TITLE
DRAFT: 218-view-single-request-test

### DIFF
--- a/cypress/e2e/request.cy.js
+++ b/cypress/e2e/request.cy.js
@@ -1,14 +1,21 @@
 describe('Viewing a single request', () => {
-  it('allows a user to view a single request.', () => {
-		// Call the custom cypress command to log in
-		cy.login(Cypress.env('TEST_SCIENTIST_USER'), Cypress.env('TEST_SCIENTIST_PW'))
+  
+  // Before each test runs: log in, visit /requests, check for noRequests or requestListExists
+  beforeEach(() => {
+    // Call the custom cypress command to log in
+    cy.login(Cypress.env('TEST_SCIENTIST_USER'), Cypress.env('TEST_SCIENTIST_PW'))
 
- 		// Visit a protected route in order to allow cypress to set the cookie and mock the login
-		cy.visit("/requests")
-    
+    // Visit a protected route in order to allow cypress to set the cookie and mock the login
+    cy.visit("/requests")
+
+    // If there are no requests, log this
+    const noRequests = cy.get('p.no-requests').contains('You do not have any requests yet.')
+
     // check that either the requests are showing, or that the user has no requests
-		const requestListExists = cy.get('article.request-item').should('exist') ||
-    cy.get('p.no-requests').contains('You do not have any requests yet.')
+    const requestListExists = cy.get('article.request-item').should('exist') || noRequests
+  })
+  
+  it('allows a user to view a single request.', () => {
 
     // if there are requests, click the first one at the top of the list
     requestListExists.then(() => {
@@ -16,9 +23,23 @@ describe('Viewing a single request', () => {
       // after clicking a request, check to make sure it navigated to the single request page successfully
       if (cy.contains('Request Info')) {
         cy.log('Successfully viewed a single request')
+      }
+    })
+	})
+
+  it("allows a user to view a request's related documents", () => {
+
+    // if there are requests, click the first one at the top of the list
+    requestListExists.then(() => {
+      // refactor if statement to make an exists
+			cy.contains(': New Request').click()
+      // after clicking a request, check to make sure it navigated to the single request page successfully
+      if (cy.contains('Request Info')) {
+        // if navigation to single request page is successful, then click View Files
+        cy.contains('View Files').click().then()
       } else {
         cy.log('Unsuccessfully viewed a single request')
       }
     })
-	})
+  })
 })

--- a/cypress/e2e/request.cy.js
+++ b/cypress/e2e/request.cy.js
@@ -13,13 +13,12 @@ describe('Viewing a single request', () => {
     // if there are requests, click the first one at the top of the list
     requestListExists.then(() => {
 			cy.contains(': New Request').click()
+      // after clicking a request, check to make sure it navigated to the single request page successfully
+      if (cy.contains('Request Info')) {
+        cy.log('Successfully viewed a single request')
+      } else {
+        cy.log('Unsuccessfully viewed a single request')
+      }
     })
-
-    // after clicking a request, check to make sure it navigated to the single request page successfully
-    if (cy.contains('Request Info')) {
-      cy.log('Successfully viewed a single request')
-    } else {
-      cy.log('Unsuccessfully viewed a single request')
-    }
 	})
 })

--- a/cypress/e2e/request.cy.js
+++ b/cypress/e2e/request.cy.js
@@ -7,27 +7,19 @@ describe('Viewing a single request', () => {
 		cy.visit("/requests")
     
     // check that either the requests are showing, or that the user has no requests
-		const requestListExists = cy.get('article.request-item').should('exist') || 
+		const requestListExists = cy.get('article.request-item').should('exist') ||
     cy.get('p.no-requests').contains('You do not have any requests yet.')
 
-    // if there are requests, click one (the first you see?)
+    // if there are requests, click the first one at the top of the list
     requestListExists.then(() => {
-			
-	})
-  
-	it("shows the user's request list if they are logged in.", () => {
-		// Call the custom cypress command to log in
-		cy.login(Cypress.env('TEST_SCIENTIST_USER'), Cypress.env('TEST_SCIENTIST_PW'))
+			cy.contains(': New Request').click()
+    })
 
-		// Visit a protected route in order to allow cypress to set the cookie and mock the login
-		cy.visit("/requests")
-
-    // check that either the requests are showing, or that the user has no requests
-		const requestListExists = cy.get('article.request-item').should('exist') || 
-    cy.get('p.no-requests').contains('You do not have any requests yet.')
-
-    requestListExists.then(() => {
-			cy.log('Successfully logged in and viewing request list')
-		})
+    // after clicking a request, check to make sure it navigated to the single request page successfully
+    if (cy.contains('Request Info')) {
+      cy.log('Successfully viewed a single request')
+    } else {
+      cy.log('Unsuccessfully viewed a single request')
+    }
 	})
 })

--- a/cypress/e2e/request.cy.js
+++ b/cypress/e2e/request.cy.js
@@ -1,0 +1,33 @@
+describe('Viewing a single request', () => {
+  it('allows a user to view a single request.', () => {
+		// Call the custom cypress command to log in
+		cy.login(Cypress.env('TEST_SCIENTIST_USER'), Cypress.env('TEST_SCIENTIST_PW'))
+
+ 		// Visit a protected route in order to allow cypress to set the cookie and mock the login
+		cy.visit("/requests")
+    
+    // check that either the requests are showing, or that the user has no requests
+		const requestListExists = cy.get('article.request-item').should('exist') || 
+    cy.get('p.no-requests').contains('You do not have any requests yet.')
+
+    // if there are requests, click one (the first you see?)
+    requestListExists.then(() => {
+			
+	})
+  
+	it("shows the user's request list if they are logged in.", () => {
+		// Call the custom cypress command to log in
+		cy.login(Cypress.env('TEST_SCIENTIST_USER'), Cypress.env('TEST_SCIENTIST_PW'))
+
+		// Visit a protected route in order to allow cypress to set the cookie and mock the login
+		cy.visit("/requests")
+
+    // check that either the requests are showing, or that the user has no requests
+		const requestListExists = cy.get('article.request-item').should('exist') || 
+    cy.get('p.no-requests').contains('You do not have any requests yet.')
+
+    requestListExists.then(() => {
+			cy.log('Successfully logged in and viewing request list')
+		})
+	})
+})


### PR DESCRIPTION
# Story

Initial draft for request.cy.js, viewing single request

Refs #218. This is just the initial draft that I've started. Adds the `request.cy.js` file, a test to view a single request.

# Expected Behavior Before Changes

Write tests for:
- [ ] Viewing a single request
     - [x] a signed in user can view an individual request page
          - Edited line 14 to include the conditional within
          - Complete. Ice box: is there a better way to test the "bad path" for line 20?
     - [ ] a signed in user can view related documents
- [ ] tests pass

# Expected Behavior After Changes

Write tests for:
- [ ] Viewing a single request
     - [ ] a signed in user can view an individual request page
     - [ ] a signed in user can view related documents
- [ ] tests pass

# Screenshots / Video

# Notes

WIP. Just wanted to begin a draft to track my thoughts and progress lol.