### PR TITLE
143 send acccess token

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -194,6 +194,7 @@ export const createRequest = async ({ dynamicFormData, wareID, accessToken }) =>
 
   if (data && dynamicFormData.attachments) {
     const attachedFiles = await createMessageOrFile({
+      accessToken,
       id: data.id,
       files: dynamicFormData.attachments,
       quotedWareID: data.quoted_ware_refs?.[0].id,


### PR DESCRIPTION
# Expected Behavior Before Changes
- we couldn't attach files when creating a request

# Expected Behavior After Changes
- send the access token to `createMessageOrFile` from `createRequest`

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes