### PR TITLE
239 page loading after request creation + disable button

### DIFF
--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -89,8 +89,8 @@ const NewRequest = () => {
       event.preventDefault()
       event.stopPropagation()
       setValidated(true)
-      setFormSubmitting(true)
     }
+    setFormSubmitting(true)
 
     if (requestForm.billingSameAsShipping === true) Object.assign(requestForm.billing, requestForm.shipping)
 

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -59,6 +59,7 @@ const NewRequest = () => {
   const [createRequestError, setCreateRequestError] = useState(undefined)
   const [createdRequestUUID, setCreatedRequestUUID] = useState(undefined)
   const [buttonDisabled, setButtonDisabled] = useState(false);
+  const [formSubmitting, setFormSubmitting] = useState(false);
 
   /**
    * @param {object} event onChange event
@@ -82,6 +83,7 @@ const NewRequest = () => {
 
   const handleSubmit = async (event) => {
     setButtonDisabled(true)
+    setFormSubmitting(true)
     if (!event.formData) {
       // these steps are needed for requests without a dynamic form
       // but error on the event resulting from the react json form
@@ -112,7 +114,7 @@ const NewRequest = () => {
   }, [createdRequestUUID])
 
   // TODO(alishaevn): use react bs placeholder component
-  if (isLoadingInitialRequest || !wareID) return <Loading wrapperClass='item-page mt-5' />
+  if (isLoadingInitialRequest || !wareID || formSubmitting) return <Loading wrapperClass='item-page mt-5' />
 
   if (!session) {
     return (

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -58,8 +58,8 @@ const NewRequest = () => {
   const [formData, setFormData] = useState(initialFormData)
   const [createRequestError, setCreateRequestError] = useState(undefined)
   const [createdRequestUUID, setCreatedRequestUUID] = useState(undefined)
-  const [buttonDisabled, setButtonDisabled] = useState(false);
-  const [formSubmitting, setFormSubmitting] = useState(false);
+  const [buttonDisabled, setButtonDisabled] = useState(false)
+  const [formSubmitting, setFormSubmitting] = useState(false)
 
   /**
    * @param {object} event onChange event
@@ -83,10 +83,10 @@ const NewRequest = () => {
 
   const handleSubmit = async (event) => {
     setButtonDisabled(true)
-    setFormSubmitting(true)
     if (!event.formData) {
       // these steps are needed for requests without a dynamic form
       // but error on the event resulting from the react json form
+      setFormSubmitting(true)
       event.preventDefault()
       event.stopPropagation()
       setValidated(true)
@@ -169,14 +169,7 @@ const NewRequest = () => {
             defaultRequiredDate={oneWeekFromNow}
             requestForm={requestForm}
             updateRequestForm={updateRequestForm}
-          />
-          <Button
-            addClass='btn btn-primary my-4 ms-auto d-block'
-            backgroundColor={buttonBg}
-            disabled={buttonDisabled}
-            label='Initiate Request'
-            type='submit'
-            size='large'
+            buttonDisabled={buttonDisabled}
           />
         </Form>
       ) : (
@@ -191,14 +184,7 @@ const NewRequest = () => {
             defaultRequiredDate={oneWeekFromNow}
             requestForm={requestForm}
             updateRequestForm={updateRequestForm}
-          />
-          <Button
-            addClass='btn btn-primary my-4 ms-auto d-block'
-            backgroundColor={buttonBg}
-            disabled={buttonDisabled}
-            label='Initiate Request'
-            type='submit'
-            size='large'
+            buttonDisabled={buttonDisabled}
           />
         </BsForm>
       )}
@@ -206,7 +192,7 @@ const NewRequest = () => {
   )
 }
 
-const StandardRequestOptions = ({ defaultRequiredDate, requestForm, updateRequestForm, }) => {
+const StandardRequestOptions = ({ buttonDisabled, defaultRequiredDate, requestForm, updateRequestForm, }) => {
   return (
     <>
       <div className='row'>
@@ -226,6 +212,14 @@ const StandardRequestOptions = ({ defaultRequiredDate, requestForm, updateReques
           />
         </div>
       </div>
+      <Button
+        addClass='btn btn-primary my-4 ms-auto d-block'
+        backgroundColor={buttonBg}
+        disabled={buttonDisabled}
+        label='Initiate Request'
+        type='submit'
+        size='large'
+      />
     </>
   )
 }

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -58,6 +58,7 @@ const NewRequest = () => {
   const [formData, setFormData] = useState(initialFormData)
   const [createRequestError, setCreateRequestError] = useState(undefined)
   const [createdRequestUUID, setCreatedRequestUUID] = useState(undefined)
+  const [buttonDisabled, setButtonDisabled] = useState(false);
 
   /**
    * @param {object} event onChange event
@@ -80,6 +81,7 @@ const NewRequest = () => {
   }
 
   const handleSubmit = async (event) => {
+    setButtonDisabled(true)
     if (!event.formData) {
       // these steps are needed for requests without a dynamic form
       // but error on the event resulting from the react json form
@@ -166,6 +168,14 @@ const NewRequest = () => {
             requestForm={requestForm}
             updateRequestForm={updateRequestForm}
           />
+          <Button
+            addClass='btn btn-primary my-4 ms-auto d-block'
+            backgroundColor={buttonBg}
+            disabled={buttonDisabled}
+            label='Initiate Request'
+            type='submit'
+            size='large'
+          />
         </Form>
       ) : (
         <BsForm
@@ -180,39 +190,42 @@ const NewRequest = () => {
             requestForm={requestForm}
             updateRequestForm={updateRequestForm}
           />
+          <Button
+            addClass='btn btn-primary my-4 ms-auto d-block'
+            backgroundColor={buttonBg}
+            disabled={buttonDisabled}
+            label='Initiate Request'
+            type='submit'
+            size='large'
+          />
         </BsForm>
       )}
     </div>
   )
 }
 
-const StandardRequestOptions = ({ defaultRequiredDate, requestForm, updateRequestForm, }) => (
-  <>
-    <div className='row'>
-      <div className='col'>
-        <ShippingDetails
-          backgroundColor={requestFormHeaderBg}
-          billingCountry={requestForm.billing.country}
-          shippingCountry={requestForm.shipping.country}
-          updateRequestForm={updateRequestForm}
-        />
+const StandardRequestOptions = ({ defaultRequiredDate, requestForm, updateRequestForm, }) => {
+  return (
+    <>
+      <div className='row'>
+        <div className='col'>
+          <ShippingDetails
+            backgroundColor={requestFormHeaderBg}
+            billingCountry={requestForm.billing.country}
+            shippingCountry={requestForm.shipping.country}
+            updateRequestForm={updateRequestForm}
+          />
+        </div>
+        <div className='col'>
+          <AdditionalInfo
+            updateRequestForm={updateRequestForm}
+            defaultRequiredDate={defaultRequiredDate}
+            backgroundColor={requestFormHeaderBg}
+          />
+        </div>
       </div>
-      <div className='col'>
-        <AdditionalInfo
-          updateRequestForm={updateRequestForm}
-          defaultRequiredDate={defaultRequiredDate}
-          backgroundColor={requestFormHeaderBg}
-        />
-      </div>
-    </div>
-    <Button
-      addClass='btn btn-primary my-4 ms-auto d-block'
-      backgroundColor={buttonBg}
-      label='Initiate Request'
-      type='submit'
-      size='large'
-    />
-  </>
-)
+    </>
+  )
+}
 
 export default NewRequest

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -84,12 +84,12 @@ const NewRequest = () => {
   const handleSubmit = async (event) => {
     setButtonDisabled(true)
     if (!event.formData) {
-      setFormSubmitting(true)
       // these steps are needed for requests without a dynamic form
       // but error on the event resulting from the react json form
       event.preventDefault()
       event.stopPropagation()
       setValidated(true)
+      setFormSubmitting(true)
     }
 
     if (requestForm.billingSameAsShipping === true) Object.assign(requestForm.billing, requestForm.shipping)

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -84,9 +84,9 @@ const NewRequest = () => {
   const handleSubmit = async (event) => {
     setButtonDisabled(true)
     if (!event.formData) {
+      setFormSubmitting(true)
       // these steps are needed for requests without a dynamic form
       // but error on the event resulting from the react json form
-      setFormSubmitting(true)
       event.preventDefault()
       event.stopPropagation()
       setValidated(true)


### PR DESCRIPTION
# Story
initiating a request makes 3 different api calls, so it takes a few seconds to transition to the next page. we should disable the button when clicked so a user doesn't click it multiples times thinking that the first didn't go through.

Refs #230 

# Expected Behavior Before Changes
user was able to click the initiate request button several times while the submit method was running, and it would cause duplicate requests

# Expected Behavior After Changes
after the button is clicked, it is disabled and the page is loading until the newly created request's page pops up

# Screenshots / Video
Video: https://share.getcloudapp.com/nOuKz9BN
