### PR TITLE
232 refresh token

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,5 +1,7 @@
 import NextAuth from 'next-auth'
 import axios from 'axios'
+// TODO(alishaevn): use the api value from https://github.com/assaydepot/rx/issues/21497 in the next phase
+import { EXPIRATION_DURATION } from '../../../utils'
 
 // For more information on each option (and a full list of options) go to: https://next-auth.js.org/configuration/options
 const authOptions = {
@@ -32,6 +34,7 @@ const authOptions = {
       if (account && user) {
         return {
           accessToken: account.access_token,
+          accessTokenExpires: Date.now() + EXPIRATION_DURATION,
           refreshToken: account.refresh_token,
           user,
         }
@@ -80,6 +83,7 @@ const refreshAccessToken = async (token) => {
     return {
       ...token,
       accessToken: refreshedTokens.access_token,
+      accessTokenExpires: Date.now() + EXPIRATION_DURATION,
       refreshToken: refreshedTokens.refresh_token ?? token.refreshToken, // Fall back to the old refresh token
     }
   } catch (error) {

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -1,4 +1,5 @@
 import NextAuth from 'next-auth'
+import axios from 'axios'
 
 // For more information on each option (and a full list of options) go to: https://next-auth.js.org/configuration/options
 const authOptions = {
@@ -28,17 +29,64 @@ const authOptions = {
   callbacks: {
     async jwt({ token, account, user }) {
       // Triggered on the initial sign in
-      // TODO(alishaevn): account for the refresh token
       if (account && user) {
-        token.accessToken = account.access_token
+        return {
+          accessToken: account.access_token,
+          refreshToken: account.refresh_token,
+          user,
+        }
       }
-      return token
+
+      // Return previous token if the access token has not expired yet
+      if (token.accessTokenExpires && (Date.now() < token.accessTokenExpires)) {
+        return token
+      }
+
+      // Access token has expired, try to update it
+      return refreshAccessToken(token)
     },
     async session({ session, token }) {
       // Send additional properties to the client
       session.accessToken = token.accessToken
       return session
     },
+  }
+}
+
+/**
+ * Takes a token, and returns a new token with an updated `accessToken`.
+ * If an error occurs, returns the old token and an error property
+ */
+const refreshAccessToken = async (token) => {
+  try {
+    const url = `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/oauth/token`
+    const encodedString = Buffer.from(`${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`).toString('base64')
+    const params = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: token.refreshToken,
+    })
+
+    const response = await axios.post(url, params, {
+      headers: {
+        'Authorization': `Basic ${encodedString}`,
+      },
+    })
+    const refreshedTokens = response.data
+
+    if (response.status !== 200) {
+      throw refreshedTokens
+    }
+
+    return {
+      ...token,
+      accessToken: refreshedTokens.access_token,
+      refreshToken: refreshedTokens.refresh_token ?? token.refreshToken, // Fall back to the old refresh token
+    }
+  } catch (error) {
+    return {
+      ...token,
+      error: 'RefreshAccessTokenError',
+    }
   }
 }
 

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -103,3 +103,8 @@ export const NAVIGATION_LINKS = [
 // change this to '/services' to have this link to a page for an individual service.
 // if you choose to go this route, you can update the content for the service's page at pages/services/[ware].js
 export const FEATURED_SERVICE_PATH = '/requests/new'
+
+// TODO(alishaevn): use the api value from https://github.com/assaydepot/rx/issues/21497 in the next phase
+// this amount, listed in milliseconds, represents when the access token will expire
+// the default is 1 week
+export const EXPIRATION_DURATION = 604800000


### PR DESCRIPTION
# Expected Behavior Before Changes
- we were not handling the refresh token

# Expected Behavior After Changes
- create the `refreshAccessToken` function to be used if a user's access token is expired
- create a local variable to determine the timeout period
  - we will use the api value from https://github.com/assaydepot/rx/issues/21497 instead in the next phase

# resources
- https://next-auth.js.org/tutorials/refresh-token-rotation
- [def refresh_token](https://github.com/assaydepot/rx/blob/c5f006b70f26a77f180e6941101fdc2b39e3d7f1/app/controllers/oauth_controller.rb#L134-L150)
- [old oauth pr](https://github.com/assaydepot/rx/pull/9551)
- https://codezup.com/3-ways-to-base64-string-encode-decode-javascript-node-js/
- https://curl.se/docs/manpage.html
- https://github.com/axios/axios#using-applicationx-www-form-urlencoded-format