### PR TITLE
Refactor api intercept function

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -41,7 +41,9 @@ Cypress.Commands.add('login', (username, password) => {
 // intercepts requests and creates potential cases for loading, error, data, and empty data
 // required params are action, defaultFixture, requestURL
 // optional params such as data, loading, and error can be passed depending on the creation of test cases that are related to that specific api call
-Cypress.Commands.add('customApiIntercept', ({ action, alias, data, defaultFixture, emptyFixture, error, errorCaseStatusCode, loading, requestURL }) => {
+Cypress.Commands.add('customApiIntercept', ({
+  action, alias, data, defaultFixture, emptyFixture, error, errorCaseStatusCode, loading, requestURL
+}) => {
   cy.intercept(action, scientistApiBaseURL + requestURL, (req) => {
     switch (true) {
       // reply with an empty response: both data and error will be undefined.

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,7 +23,7 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-
+import { scientistApiBaseURL } from "./e2e";
 
 // add a command to login that uses a session, so the user will remain logged in throughout the test file vs. needing to log in before each example.
 // source: https://github.com/nextauthjs/next-auth/discussions/2053#discussioncomment-1191016
@@ -36,4 +36,32 @@ Cypress.Commands.add('login', (username, password) => {
 	// This cookie also may need to be refreshed intermittently if it expires
 	cy.setCookie("next-auth.session-token", Cypress.env('TEST_SESSION_COOKIE'));
   })
+})
+
+// intercepts requests and creates potential cases for loading, error, data, and empty data
+// required params are action, defaultFixture, requestURL
+// optional params such as data, loading, and error can be passed depending on the creation of test cases that are related to that specific api call
+Cypress.Commands.add('customApiIntercept', ({ action, alias, data, defaultFixture, emptyFixture, error, errorCaseStatusCode, loading, requestURL }) => {
+  cy.intercept(action, scientistApiBaseURL + requestURL, (req) => {
+    switch (true) {
+      // reply with an empty response: both data and error will be undefined.
+      case loading: req.reply()
+      break
+
+      // error will be defined
+      case error: req.reply({ statusCode: errorCaseStatusCode || 500 })
+      break
+
+      // reply with a request body- default status code is 200
+      case data: req.reply({ fixture: defaultFixture })
+      break
+
+      // reply with the empty fixture is there is one, and the default as a backup. Allows us to isolate one api call at a time that may potentially respond with empty data.
+      case !data: req.reply({ fixture: emptyFixture || defaultFixture })
+      break
+
+      default: req.reply({ fixture: defaultFixture })
+      break
+    }
+  }).as(alias || 'customIntercept')
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,7 +23,7 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-import { scientistApiBaseURL } from "./e2e";
+import { scientistApiBaseURL } from './e2e'
 
 // add a command to login that uses a session, so the user will remain logged in throughout the test file vs. needing to log in before each example.
 // source: https://github.com/nextauthjs/next-auth/discussions/2053#discussioncomment-1191016

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -16,5 +16,4 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
+export const scientistApiBaseURL = `https://${Cypress.env('NEXT_PUBLIC_PROVIDER_NAME')}.scientist.com/api/v2`


### PR DESCRIPTION
- refactor api intercept function to be a cypress custom command, and use in requests.cy.js
- intercept needs to be added as many times as the number of api calls exist on a page, so it was getting long. this will help us avoid rewriting repetitive intercepts for every page of tests
- also moves the scientistApiBaseURL variable since it will likely be used throughout most of the e2e tests

# Expected Behavior After Changes
- can use scientistApiBaseUrl variable
- can use customApiIntercept cypress command