### PR TITLE
143 check for ware ref

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -196,7 +196,7 @@ export const createRequest = async ({ dynamicFormData, wareID, accessToken }) =>
     /**
      * TODO(alishaevn): I'm not sure why, but sometimes our data does not have the "quoted_ware_refs" property on it.
      * a search for the request in postman however, returns the property. we should find the underlying commonality on
-     * requests that don't return the value so we can fix it.
+     * requests that don't return the value so we can fix it. (ref: https://github.com/scientist-softserv/webstore/issues/252)
      */
     let quotedWareID = data.quoted_ware_refs?.[0]?.id
     if (!quotedWareID) {

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -7,7 +7,7 @@ import {
   configureMessages,
   configureRequests,
 } from './configurations'
-import { posting } from './base'
+import { fetcher, posting } from './base'
 
 /** GET METHODS */
 export const useAllRequests = (accessToken) => {
@@ -193,11 +193,23 @@ export const createRequest = async ({ dynamicFormData, wareID, accessToken }) =>
   let { data, error } = await posting(`/wares/${wareID}/quote_groups.json`, { pg_quote_group }, accessToken)
 
   if (data && dynamicFormData.attachments) {
+    /**
+     * TODO(alishaevn): I'm not sure why, but sometimes our data does not have the "quoted_ware_refs" property on it.
+     * a search for the request in postman however, returns the property. we should find the underlying commonality on
+     * requests that don't return the value so we can fix it.
+     */
+    let quotedWareID = data.quoted_ware_refs?.[0]?.id
+    if (!quotedWareID) {
+      // we have to explicity use fetcher because "useOneRequest" is a hook
+      const res = await fetcher(`/quote_groups/${data.id}.json`, accessToken)
+      quotedWareID = res.quoted_ware_refs?.[0]?.id
+    }
+
     const attachedFiles = await createMessageOrFile({
       accessToken,
       id: data.id,
       files: dynamicFormData.attachments,
-      quotedWareID: data.quoted_ware_refs?.[0].id,
+      quotedWareID,
     })
 
     if (attachedFiles.error) {


### PR DESCRIPTION
# Story
I'm not sure why, but sometimes our data does not have the "quoted_ware_refs" property on it. a search for the request in postman however, returns the property.

# Expected Behavior Before Changes
- sometimes a newly created request does not return the quoted ware, so creating the attachments fails

# Expected Behavior After Changes
- add a fallback for "data.quoted_ware_refs?.[0]?.id" when creating a request with attachments
