### PR TITLE
280 create requests correctly

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -177,7 +177,7 @@ const requestData = ({request, shipping, billing}) => {
     proposed_deadline_str: request.proposedDeadline,
     site: {
       billing_same_as_shipping: request.billingSameAsShipping,
-      name: request.name,
+      name: process.env.NEXT_PUBLIC_PROVIDER_NAME,
     },
     shipping_address_attributes: {
       city: shipping.city,


### PR DESCRIPTION
# Story
I noticed on staging that creating a new request does not navigate to the request show page now that we've switched to using the beachside supplier. it continually shows the loading spinner until you manually navigate from the page. returning to "/requests" does show the recently created request however.

# Expected Behavior After Changes
- pass the org name and not the request name as the "site.name" value

# Notes
[related thread](https://assaydepot.slack.com/archives/C03FZDALABG/p1679000272365949?thread_ts=1678905651.795149&cid=C03FZDALABG)