### PR TITLE
hide arrays from dynamic form

### DIFF
--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -278,6 +278,7 @@ export const configureDynamicFormSchema = (defaultSchema) => {
 
       if (value.type !== 'array') {
         // TODO(alishaevn): figure out the "items" property for arrays
+        // ref: https://react-jsonschema-form.readthedocs.io/en/v1.8.1/form-customization/#form-customization
         propertyFields[key] = adjustedProperty
       }
     }

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -276,7 +276,10 @@ export const configureDynamicFormSchema = (defaultSchema) => {
         adjustedProperty = { ...remainingProperties }
       }
 
-      propertyFields[key] = adjustedProperty
+      if (value.type !== 'array') {
+        // TODO(alishaevn): figure out the "items" property for arrays
+        propertyFields[key] = adjustedProperty
+      }
     }
   })
 


### PR DESCRIPTION
# story
the sales team would like a more complicated request form for the demo. some of the more complex forms include array property's which are currently not accounted for in the mvp app. this change will hide those properties until another phase of work where we can make that happen.

# Expected Behavior Before Changes
![Screenshot 2023-03-20 at 9 49 54 AM](https://user-images.githubusercontent.com/29032869/226503378-1cce12b8-987d-45e7-ad71-166b313148e2.png)


# Expected Behavior After Changes
- hide properties that have an array type from the dynamic form
# Screenshots / Video
<img width="780" alt="image" src="https://user-images.githubusercontent.com/29032869/226503587-e08f7f10-f09e-4f6a-a47a-606ed607cebb.png">


# Notes
