### PR TITLE
fix the default ware

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -141,10 +141,12 @@ export const useInitializeRequest = (id, accessToken) => {
 }
 
 export const useDefaultWare = (accessToken) => {
-  const { data, error } = useSWR([`/wares.json?q=make-a-request`, accessToken])
+  const { data, error } = useSWR([`/wares.json`, accessToken])
+  const defaultWare = data?.ware_refs?.find(item => item.slug === 'make-a-request')
 
   return {
-    defaultWareID: data?.ware_refs?.[0]?.id,
+    // TODO(alishaevn): check this still works with the next client
+    defaultWareID: defaultWare?.id,
     isLoadingDefaultWare: !error && !data,
     isDefaultWareError: error,
   }


### PR DESCRIPTION
# Story
how we find the default ware is different for the beachside biotech org. this change may reflect how all new org's that only represent a single provider are created. we'll have to double check that when the next org is created however.

Refs #issuenumber

# Expected Behavior Before Changes
- we were not returning the default ware id

# Expected Behavior After Changes
- we're returning the default ware id