### PR TITLE
292 reduce sentry errors

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -91,6 +91,8 @@ export const useMessages = (requestUuid, accessToken) => {
     messages = configureMessages(data.messages)
   }
 
+  // TODO(alishaevn): check that we don't need to change anything here when
+  // https://github.com/assaydepot/scientist_api_v2/issues/251 is resolved
   return {
     messages,
     mutateMessages: mutate,

--- a/utils/api/webhooks.js
+++ b/utils/api/webhooks.js
@@ -4,7 +4,8 @@ import { WEBHOOK_EVENTS } from '../constants'
 export const getWebhookConfig = async (accessToken) => {
   // TODO(alishaevn): update the url to "webhook_config/user.json" when
   // https://github.com/assaydepot/scientist_api_v2/pull/237 is available on api prod
-  return fetcher('/webhook_config.json', accessToken)
+  const url = () => accessToken ? '/webhook_config.json' : null
+  return fetcher(url(), accessToken)
 }
 
 export const createWebhookConfig = (accessToken) => {
@@ -25,5 +26,6 @@ export const createWebhookConfig = (accessToken) => {
 
   // TODO(alishaevn): update the url to "webhook_config/user.json" when
   // https://github.com/assaydepot/scientist_api_v2/pull/237 is available on api prod
-  updating('/webhook_config.json', webhook_config, accessToken)
+  const url = () => accessToken ? '/webhook_config.json' : null
+  updating(url(), webhook_config, accessToken)
 }


### PR DESCRIPTION
related: https://github.com/scientist-softserv/webstore/pull/168

# Expected Behavior After Changes
- check for access tokens before making request or webhook related api calls. 14k related sentry errors for "No access token provided."
  - using `accessToken` for all calls regardless of other args since the accessToken is what fails. also, none of the other arguments seem to throw errors.
- add comment referencing https://github.com/assaydepot/scientist_api_v2/issues/251

# demo
<details>
<summary>expected flow through the app</summary>

- unsure why the favicon sometimes can't be found immediately. that's not an api error though
- also unsure why the promo image has issues sometimes. the `/ware` endpoints don't require a user specific access token though so it's also unrelated to these changes
- the 301 moved permanently error for the user avatar is already noted in the code comments. there's a corresponding api ticket

https://user-images.githubusercontent.com/29032869/228346963-64f85f14-2f16-4753-b050-c28c092c1984.mp4
</details>

<details>
<summary>request show page when the uuid is wrong</summary>

- the page would stay in "loading". not a high priority issue in a prod environment because the uuid is pulled from the api. the error below was because I manually changed the uuid to something that didn't exist
- 
![image](https://user-images.githubusercontent.com/29032869/228347812-c020579a-5905-4ca2-b3ff-8a0c10f58c10.png)
</details>

<details>
<summary>request show page when the request is not found</summary>

- I manually changed the code so that `request = {}`
- in that case, `request.id`, `request.uuid`, etc would be undefined

![image](https://user-images.githubusercontent.com/29032869/228349381-bcf19449-aedd-4649-b63e-0446f477e9e1.png)
<details>