### PR TITLE
135-fix-base-url

### DIFF
--- a/.env
+++ b/.env
@@ -5,4 +5,4 @@ NEXT_PUBLIC_PROVIDER_NAME=beachsidebiotech
 NEXT_PUBLIC_PROVIDER_ID=5159
 NEXT_PUBLIC_SCIENTIST_API_VERSION=v2
 NEXT_PUBLIC_WEBHOOK_URL=http://ss-mailer/webstore
-NEXT_PUBLIC_APP_BASE_URL=https://www.webstore-staging.vercel.app
+NEXT_PUBLIC_APP_BASE_URL=https://webstore-staging.vercel.app


### PR DESCRIPTION
# Story
while testing email webhooks last friday:
> I signed out and back in to the staging site. I then created a new request and sent a proposal from the backoffice. the email I received is below. in clicking the link I was routed to the webstore, but given a "Did Not Connect: Potential Security Issue" error.

> the link to my created request is: https://webstore-staging.vercel.app/requests/c98ac1b9-9b91-467a-b5b7-24c9fc65659a
the link that I was redirected to from the email is: https://www.webstore-staging.vercel.app/requests/c98ac1b9-9b91-467a-b5b7-24c9fc65659a

> looks like the email added "www" to the url. once I removed the "www" from the url, I was taken to the correct request with an sow.

# Expected Behavior After Changes
- remove "www." from the `NEXT_PUBLIC_APP_BASE_URL` so that the emails get redirected correctly
