### PR TITLE
135-set-webhook-in-refreshAccessToken

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -88,6 +88,12 @@ const refreshAccessToken = async (token) => {
       throw refreshedTokens
     }
 
+    // add the webstore webhook if it isn't there
+    const data = await getWebhookConfig(refreshedTokens.access_token)
+    if(!data?.id) {
+      createWebhookConfig(refreshedTokens.access_token)
+    }
+
     return {
       ...token,
       accessToken: refreshedTokens.access_token,


### PR DESCRIPTION
# Story
only users signing in with oauth get the email webhook set up

# Expected Behavior After Changes
- users who are re-authenticating with their refresh token get email webhooks too
