### PR TITLE
sentry conditionally

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,12 @@
 // or the sentry project hasn't been set up yet
 if (!process.env.SENTRY_DSN && !process.env.NEXT_PUBLIC_SENTRY_DSN) return
 
+// This file sets a custom webpack configuration to use your Next.js app
+// with Sentry.
+// https://nextjs.org/docs/api-reference/next.config.js/introduction
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+const { withSentryConfig } = require('@sentry/nextjs')
+
 /** @type {import('next').NextConfig} */
 const moduleExports = {
   output: 'standalone',

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,6 @@
-// This file sets a custom webpack configuration to use your Next.js app
-// with Sentry.
-// https://nextjs.org/docs/api-reference/next.config.js/introduction
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
-const { withSentryConfig } = require('@sentry/nextjs')
+// This guard clause allows the app to still build in the event another exception handler will be used,
+// or the sentry project hasn't been set up yet
+if (!process.env.SENTRY_DSN && !process.env.NEXT_PUBLIC_SENTRY_DSN) return
 
 /** @type {import('next').NextConfig} */
 const moduleExports = {


### PR DESCRIPTION
# Story
conditional sentry exception handling

clients ought to have the option to use whichever exception handler they want, not only sentry. by default, the apps that are set up by softserv will use sentry however. this change allows the app to still build whether the sentry values in .env.local are set or not. whether that means the app will use something other than sentry, or the sentry project has not been set up yet

related:
- https://github.com/scientist-softserv/phenovista-digital-storefront/issues/5

# Expected Behavior Before Changes
<details>
<summary>the build failed</summary>

<img width="1313" alt="image" src="https://github.com/scientist-softserv/webstore/assets/29032869/45f09e7c-83ce-479f-89c6-b5ccefb8f917">
</details>

# Expected Behavior After Changes
<details>
<summary>the build succeeds</summary>

<img width="980" alt="image" src="https://github.com/scientist-softserv/webstore/assets/29032869/cd8f8bf9-88e8-4964-902a-dd5daf86e4a0">
</details>