### PR TITLE
308-unable-to-view-requests

### DIFF
--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -64,7 +64,7 @@ export const getAllPOs = async (quotedWareId, uuid, requestIdentifier, accessTok
     // See https://github.com/vercel/swr/discussions/1988 for the RFC and https://github.com/vercel/swr/pull/2047 for the PR.
     const url = () => accessToken ? `quote_groups/${uuid}/quoted_wares/${quotedWareId}/purchase_orders.json` : null
     const data = await fetcher(url(), accessToken)
-    const configuredPOs = data?.map(async (po) => {
+    const configuredPOs = data?.purchase_orders.map(async (po) => {
       const purchaseOrder = await fetcher(`quote_groups/${uuid}/quoted_wares/${quotedWareId}/purchase_orders/${po.id}.json`, accessToken)
       return configurePO(purchaseOrder, requestIdentifier)
     })


### PR DESCRIPTION
# Story
restore ability to look at individual requests again.
this change is necessary because of the change in PurchaseOrdersController#index in commit 71077c6 of the api.

- #308 

# Expected Behavior Before Changes
- trying to map over a hash (which was previously an array) was throwing an error

<details>
<summary>error</summary>

<img width="1360" alt="image" src="https://github.com/scientist-softserv/webstore/assets/29032869/179476b6-8b99-4dee-ae30-f1b58f1dd185">
</details>

# Expected Behavior After Changes
- the data is properly being found

# Screenshots / Video



# Notes
