### PR TITLE
325-unauthed-experience

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,6 +19,9 @@ import {
 import '../utils/theme/globals.scss'
 
 const WebStore = ({ Component }) => {
+  /**
+   * the session will return undefined if it's still loading, null if the user is not logged in, or an object if the user is logged in.
+   */
   const { data: session } = useSession()
   const router = useRouter()
 

--- a/pages/requests/[uuid].js
+++ b/pages/requests/[uuid].js
@@ -58,25 +58,22 @@ const Request = ({ session }) => {
     }
   }, [request, isLoadingPOs, accessToken, uuid])
 
+  /**
+   * checking for the presence of a session has to come after all of the hooks so we don't violate the react-hooks/rules-of-hooks
+   * rule. ref: https://legacy.reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+   * we return the loading state in two different locations because it's rendered based on separate conditions. when
+   * isLoading is true because we don't have a user, it doesn't ever become false. that's why we were previously returning
+   * the loading spinner indefinitely.
+   * using a guard clause with an early return inside the api methods also violates the react-hooks/rules-of-hooks rule.
+   */
+  if (session === undefined) return pageLoading
+  if (session === null) return unauthorizedUser
+
   const isLoading = isLoadingRequest || isLoadingSOWs || isLoadingFiles || isLoadingMessages
   const isError = isRequestError || isSOWError || isFilesError|| isMessagesError || isPOError
   const documents = (allSOWs) ? [...allSOWs, ...allPOs] : []
 
-  if (isLoading) return <Loading wrapperClass='item-page mt-5' />
-
-  if (!session) {
-    return (
-      <Notice
-        addClass='my-5'
-        alert={{
-          body: ['Please log in to view this request.'],
-          title: 'Unauthorized',
-          variant: 'info'
-        }}
-        dismissible={false}
-      />
-    )
-  }
+  if (isLoading) return pageLoading
 
   // this error is a result of creating the request
   if (createRequestError) {
@@ -218,5 +215,19 @@ const Request = ({ session }) => {
     </div>
   )
 }
+
+const pageLoading = <Loading wrapperClass='item-page mt-5' />
+
+const unauthorizedUser = (
+  <Notice
+    addClass='my-5'
+    alert={{
+      body: ['Please log in to view this request.'],
+      title: 'Unauthorized',
+      variant: 'info'
+    }}
+    dismissible={false}
+  />
+)
 
 export default Request

--- a/pages/requests/index.js
+++ b/pages/requests/index.js
@@ -22,23 +22,17 @@ const Requests = ({ session }) => {
   const isError = isAllRequestsError || isDefaultWareError
   const isLoading = isLoadingAllRequests || isLoadingDefaultWare
 
-  // Check whether the user is authenticated first. If it does, we can return the API errors if applicable.
-
-  if (isLoading) return <Loading wrapperClass='mt-5' />
-
-  if (!session) {
-    return (
-      <Notice
-        addClass='my-5'
-        alert={{
-          body: ['Please log in to make new requests or view existing ones.'],
-          title: 'Unauthorized',
-          variant: 'info'
-        }}
-        dismissible={false}
-      />
-    )
-  }
+  /**
+   * checking for the presence of a session has to come after all of the hooks so we don't violate the react-hooks/rules-of-hooks
+   * rule. ref: https://legacy.reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+   * we return the loading state in two different locations because it's rendered based on separate conditions. when
+   * isLoading is true because we don't have a user, it doesn't ever become false. that's why we were previously returning
+   * the loading spinner indefinitely.
+   * using a guard clause with an early return inside the api methods also violates the react-hooks/rules-of-hooks rule.
+   */
+  if (session === undefined) return pageLoading
+  if (session === null) return unauthorizedUser
+  if (isLoading) return pageLoading
 
   if (isError) {
     return (
@@ -71,5 +65,19 @@ const Requests = ({ session }) => {
     </div>
   )
 }
+
+const pageLoading = <Loading wrapperClass='mt-5' />
+
+const unauthorizedUser = (
+  <Notice
+    addClass='my-5'
+    alert={{
+      body: ['Please log in to make new requests or view existing ones.'],
+      title: 'Unauthorized',
+      variant: 'info'
+    }}
+    dismissible={false}
+  />
+)
 
 export default Requests


### PR DESCRIPTION
- #325 

# Story
correctly block unauthed users from pages that require auth

previously, a page that required authorization would show the spinning modal indefinitely, instead of showing the message that informs the user they must be signed in. this is because the variable that determined whether the spinner should show, always remained true.

this commit breaks out the logic to first check if there is a user. what renders on the page is based on that.

checking for the presence of a session has to come after all of the hooks so we don't violate the react-hooks/rules-of-hooks rule. ref: https://legacy.reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level we return the loading state in two different locations because it's rendered based on separate conditions. when isLoading is true because we don't have a user, it doesn't ever become false. that's why we were previously returning the loading spinner indefinitely. using a guard clause with an early return inside the api methods also violates the react-hooks/rules-of-hooks rule.

# Screenshots / Video

https://github.com/scientist-softserv/webstore/assets/29032869/62370bdc-06a9-4659-bf49-b0d05e0f418a

# Testing
- visit "/requests" as a logged out user
- verify that you see messaging about signing in, not a loading spinner (could take 3-5 seconds)