### PR TITLE
327 browse all wares

### DIFF
--- a/utils/api/services.js
+++ b/utils/api/services.js
@@ -1,8 +1,9 @@
 import useSWR from 'swr'
+import { API_PER_PAGE } from '../constants'
 
 /** GET METHODS */
 export const useAllWares = (accessToken) => {
-  const { data, error } = useSWR([`/wares.json`, accessToken])
+  const { data, error } = useSWR([`/wares.json?per_page=${API_PER_PAGE}`, accessToken])
 
   return {
     wares: data?.ware_refs,
@@ -12,7 +13,7 @@ export const useAllWares = (accessToken) => {
 }
 
 export const useFilteredWares = (query, accessToken) => {
-  const { data, error } = useSWR([`/wares.json?q=${query}`, accessToken])
+  const { data, error } = useSWR([`/wares.json?per_page=${API_PER_PAGE}&q=${query}`, accessToken])
 
   return {
     wares: data?.ware_refs.filter(item => item.slug !== 'make-a-request'),

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -127,6 +127,8 @@ export const FEATURED_SERVICE_PATH = '/requests/new'
 // the default is 1 week
 export const EXPIRATION_DURATION = 604800000
 
+export const API_PER_PAGE = 2000
+
 export const WEBHOOK_EVENTS = {
   'signer': {
     'signature_voided': false,


### PR DESCRIPTION
- #327 

return all wares for the given marketplace

the default api setting is to return 25 wares per page. so, we were only returning 25 wares total on the browse page. we now are returning "all" wares by choosing to get 2000 wares per page in the api request. I didn't see a way to set `page: "all"` or `per_page: "all"`.

if a marketplace has more than 2000 wares, we will need to increase the number.

# Screenshots / Video
<details>
<summary> postman api call</summary>

<img width="963" alt="image" src="https://github.com/scientist-softserv/webstore/assets/29032869/9e046ef5-aa12-4f29-ae20-f2e5cad13c50">
</details>

https://github.com/scientist-softserv/webstore/assets/29032869/278594d7-2e05-42da-a1ff-304578b12f27
