### PR TITLE
342 unable to create requests

### DIFF
--- a/cypress/fixtures/one-request/files.json
+++ b/cypress/fixtures/one-request/files.json
@@ -16,7 +16,6 @@
               "email": "summer@scientist.com",
               "title": "Frontend Dev",
               "company": "",
-              "site": "{\"name\"=>\"Cell Based Assays\", \"billing_same_as_shipping\"=>true}",
               "image": "https://avatars.scientist.com/avatars/0d93b3808f701fc3dbde5002a80c2475/S C/xs?time=1677774999"
           }
       }

--- a/cypress/fixtures/one-request/messages.json
+++ b/cypress/fixtures/one-request/messages.json
@@ -16,7 +16,6 @@
               "email": "sherman@scientist.com",
               "title": "Master tester",
               "company": "",
-              "site": "Asia",
               "image": "https://avatars.scientist.com/avatars/20c7e703deca8fcabb2df42096142740/S T/xs?time=1677774999"
           },
           "proposal_ref": {
@@ -67,7 +66,6 @@
               "email": "summer@scientist.com",
               "title": "Frontend Dev",
               "company": "",
-              "site": "{\"name\"=>\"Cell Based Assays\", \"billing_same_as_shipping\"=>true}",
               "image": "https://avatars.scientist.com/avatars/0d93b3808f701fc3dbde5002a80c2475/S C/xs?time=1677774999"
           }
       }

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -181,10 +181,6 @@ const requestData = ({request, shipping, billing}) => {
     /* eslint-disable camelcase */
     provider_ids: [process.env.NEXT_PUBLIC_PROVIDER_ID],
     proposed_deadline_str: request.proposedDeadline,
-    site: {
-      billing_same_as_shipping: request.billingSameAsShipping,
-      name: process.env.NEXT_PUBLIC_PROVIDER_NAME,
-    },
     shipping_address_attributes: {
       city: shipping.city,
       country: shipping.country,


### PR DESCRIPTION
# Story
removed the `site` property from the request object because it erred in the API (ref: [slack thread](https://assaydepot.slack.com/archives/CF6490Y80/p1705017664697359?thread_ts=1704996805.983419&cid=CF6490Y80))

- #342 

# Expected Behavior After Changes
- we are able to create requests once more

# Screenshots / Video

https://github.com/scientist-softserv/webstore/assets/29032869/3948089c-df1c-406e-90c4-68f90313ba61
