### PR TITLE
Show description and not snippet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ node_modules/
 cypress/results
 cypress/screenshots
 cypress/videos
+
+.DS_Store

--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -15,7 +15,7 @@ export const configureServices = ({ data, path }) => {
       : DEFAULT_WARE_IMAGE
 
     return {
-      description: ware.snippet,
+      description: ware.description,
       id: ware.id,
       img,
       name: ware.name,


### PR DESCRIPTION
# Story
we needed to use the description instead of the snippet in the useAllWares api call. The 

# related
- https://github.com/scientist-softserv/webstore-component-library/issues/199
- component lib pr: https://github.com/scientist-softserv/webstore-component-library/pull/204

# Expected Behavior Before Changes
the snippet was showing on the browse page in the ware cards

# Expected Behavior After Changes
the description should be showing on the browse page in the ware cards

# Screenshots / Video

# screenshot/video
video: 
https://share.zight.com/04uROEJk

screenshot:
<img width="1335" alt="image" src="https://github.com/scientist-softserv/webstore-component-library/assets/73361970/09c6a2a3-24b8-4d48-ae97-f706240863ff">


# Notes
