### PR TITLE
321-restore-login

### DIFF
--- a/utils/api/base.js
+++ b/utils/api/base.js
@@ -11,7 +11,10 @@ export const fetcher = (url, token) => {
     .then(res => res.data)
     .catch(error => {
       Sentry.captureException(error)
-      throw error
+      // the `signIn` function from "next-auth/react" uses `fetcher` and returns a 404 error response. throwing that error causes an
+      // `OAUTH_CALLBACK_HANDLER_ERROR`, which prevents users from signing in. `signIn` doesn't pass a url to `fetcher`. the check below
+      // ensures that other errors still get thrown
+      if (error.config.url !== null) throw error
     })
 }
 


### PR DESCRIPTION
# Story
able to log in again

the `signIn` function from "next-auth/react" uses `fetcher` and returns a 404 error response. throwing that error causes an `OAUTH_CALLBACK_HANDLER_ERROR`, which prevents users from signing in. `signIn` doesn't pass a url to `fetcher`. the check below ensures that other errors still get thrown

- ref: https://github.com/scientist-softserv/webstore/issues/321

# Screenshots / Video

https://github.com/scientist-softserv/webstore/assets/29032869/d0aaa6b6-df1e-48cd-a2d9-9607e4ee93c1